### PR TITLE
Profile ergonomics (timeline, fluent builders, serialization) + typed deco-model layer

### DIFF
--- a/.claude/codebase-index.md
+++ b/.claude/codebase-index.md
@@ -1,0 +1,317 @@
+# diveplan codebase index
+
+Auto-generated API map (regenerate: `uv run python .claude/generate-index.py`). Generated 2026-07-05.
+
+Read this instead of source files when you only need signatures/structure. Read the actual source before *editing* anything listed here.
+
+## `src/diveplan/__init__.py`
+diveplan — dive planning and decompression calculation library.
+### class `_ConfigProxy` — Transparent proxy to DiveConfig.current().
+  `__slots__ = ()`
+  - @property `gas(self) -> _GasConfig`
+  - @property `physics(self) -> _PhysicsConfig`
+  - @property `planning(self) -> _DivePlanningConfig`
+  dunders: `__repr__, __str__`
+- const `diveconfig = _ConfigProxy()`
+`__all__ = ['Pressure', 'Gas', 'DiveSegment', 'SegmentKind', 'DiveConfig', 'diveconfig']`
+
+## `src/diveplan/core/__init__.py`
+Core value objects and configuration for diveplan.
+
+## `src/diveplan/core/config.py`
+diveplan.core.config
+- const `logger = logging.getLogger(__name__)`
+`__all__ = ['DiveConfig']`
+### class `_SubConfig` (BaseModel) — Base class for all DiveConfig sub-configs.
+  attrs: `model_config = ConfigDict(validate_assignment=True)`
+  dunders: `__repr__, __str__`
+### class `_PhysicsConfig` (_SubConfig) — Physical constants for the dive environment.
+  - @property `pressure_per_meter_mbar(self) -> float`  — Pressure increase per meter of depth in mbar.
+  attrs: `water_density: float = Field(default=1.025, gt=0, description='kg/L — 1.025 seawater, 1.0 freshwater'); gravity: float = Field(default=9.80665, gt=0, description='m/s²'); surface_pressure_mbar: int = Field(default=1013, gt=0, description='mbar — sea level ~1013, lower at altitude')`
+### class `_DivePlanningConfig` (_SubConfig) — Ascent/descent rates and stop parameters.
+  attrs: `ascent_rate: float = Field(default=9.0, gt=0, description='m/min'); descent_rate: float = Field(default=20.0, gt=0, description='m/min'); stop_increment_m: float = Field(default=3.0, gt=0, description='meters between deco stops'); last_stop_m: float = Field(default=3.0, gt=0, description='depth of last deco stop in meters'); min_stop_time_s: int = Field(default=60, gt=0, description='minimum time at each stop in seconds'); sample_rate_s: int = Field(default=1, gt=0, description='integration sample rate in seconds'); default_model: str = Field(default='zhl16c', description='registry name of default deco model')`
+### class `_GasConfig` (_SubConfig) — Gas planning limits and SAC rates.
+  attrs: `min_ppo2_bar: float = Field(default=0.18, gt=0, description='bar — hypoxia floor'); max_ppo2_bar: float = Field(default=1.4, gt=0, description='bar — working/bottom ppO2 limit'); deco_ppo2_bar: float = Field(default=1.6, gt=0, description='bar — ppO2 limit at deco stops'); max_ppn2_bar: float = Field(default=3.2, gt=0, description='bar — narcosis/ppN2 ceiling'); max_end_m: float = Field(default=30.0, gt=0, description='meters — maximum equivalent narcotic depth'); sac_bottom: float = Field(default=20.0, gt=0, description='L/min — surface air consumption at bottom'); sac_deco: float = Field(default=15.0, gt=0, description='L/min — surface air consumption at deco stops'); gas_switch_minutes: float = Field(default=1.0, ge=0, description='minutes added per gas switch — 0 = instant'); gas_switch_at_stops_only: bool = Field(default=True, description='if True, gas switches only allowed at deco stops')`
+- `_try_load(path: Path | str, source: str, config_cls: type[DiveConfig]) -> DiveConfig | None`  — Attempt to load a DiveConfig from a file. Returns None on any failure.
+- `_load_default_config() -> DiveConfig`  — Resolve the startup default config following the priority chain:
+### class `DiveConfig` (BaseModel) — Root configuration object.
+  - @classmethod `current(cls) -> DiveConfig`  — Return the active config — top of the (context-local) stack, or startup default.
+  - @classmethod `set_default(cls, config: DiveConfig) -> None`  — Permanently replace the global default config.
+  - @classmethod `reset_default(cls) -> None`  — Restore factory defaults and clear the stack — useful in tests.
+  - `__enter__(self) -> DiveConfig`
+  - `__exit__(self, *_) -> None`
+  - `to_json(self, path: str | None = None, indent: int = 2) -> str`  — Serialize to JSON string, optionally writing to file.
+  - @classmethod `from_json(cls, data: str | None = None, path: str | None = None) -> DiveConfig`  — Deserialize from JSON string or file path.
+  attrs: `model_config = ConfigDict(frozen=True); physics: _PhysicsConfig = Field(default_factory=_PhysicsConfig); planning: _DivePlanningConfig = Field(default_factory=_DivePlanningConfig); gas: _GasConfig = Field(default_factory=_GasConfig)`
+  dunders: `__repr__, __str__`
+
+## `src/diveplan/core/dive_segment.py`
+`__all__ = ['SegmentKind', 'DiveSegment']`
+### class `SegmentKind` — Kind of dive segment, used for categorization and special handling in algorithms.
+  - class `Descent` (Enum)
+    attrs: `DESCENT = auto()`
+  - class `Ascent` (Enum)
+    attrs: `FORCED_ASCENT = auto(); DECO_ASCENT = auto()`
+  - class `Constant` (Enum)
+    attrs: `BOTTOM = auto(); STOP = auto(); GAS_SWITCH = auto()`
+  - @staticmethod `from_name(name: str) -> SegmentKind.Members`  — Look up a segment kind by member name, e.g. ``"DESCENT"``, ``"STOP"``.
+  attrs: `DESCENT = Descent.DESCENT; ASCENT = Ascent.FORCED_ASCENT; CONSTANT = Constant.BOTTOM; Members = Descent | Ascent | Constant`
+### class `DiveSegment` — A segment of a dive profile with a start and end pressure, duration, and gas.
+  `__slots__ = ('start_pressure', 'end_pressure', 'duration', 'gas', 'kind')`
+  - `__init__(self, start_pressure: Pressure, end_pressure: Pressure, duration: timedelta | int | float, gas: Gas, *, ascent_kind: SegmentKind.Ascent = SegmentKind.ASCENT, constant_kind: SegmentKind.Constant = SegmentKind.CONSTANT)`  — Args:
+  - `_determine_kind(self, ascent_kind: SegmentKind.Ascent, constant_kind: SegmentKind.Constant) -> SegmentKind.Members`
+  - @property `average_pressure(self) -> Pressure`  — Mean of the start and end pressures.
+  - @property `absolute_pressure_change(self) -> Pressure`  — Magnitude of the pressure change from start to end (always non-negative).
+  - @property `pressure_rate(self) -> float`  — Signed rate of pressure change in mbar per second.
+  - `_validate_time(self, t: timedelta) -> None`
+  - `_validate_fraction(self, fraction: float) -> None`
+  - `_validate_pressure(self, pressure: Pressure) -> None`
+  - `pressure_at_time(self, t: timedelta) -> Pressure`  — Pressure at time t into the segment. Linear interpolation.
+  - `pressure_at_fraction(self, fraction: float) -> Pressure`  — Pressure at fraction (0 to 1) into the segment. Linear interpolation.
+  - `time_at_pressure(self, pressure: Pressure) -> timedelta`  — Time at which a given pressure is reached. Linear interpolation.
+  - `time_at_fraction(self, fraction: float) -> timedelta`  — Time at which a given fraction (0 to 1) is reached. Linear interpolation.
+  - `fraction_at_pressure(self, pressure: Pressure) -> float`  — Fraction (0 to 1) at which a given pressure is reached. Linear interpolation.
+  - `fraction_at_time(self, t: timedelta) -> float`  — Fraction (0 to 1) at time t into the segment. Linear interpolation.
+  - `split_at_time(self, t: timedelta) -> tuple[DiveSegment, DiveSegment]`  — Split into two segments at time t — useful for injecting a gas switch mid-segment.
+  - `split_at_fraction(self, fraction: float) -> tuple[DiveSegment, DiveSegment]`  — Split into two segments at fraction (0 to 1) — useful for injecting a gas switch mid-segment.
+  - `merge_with(self, other: DiveSegment, *, force: bool = False) -> DiveSegment`  — Merge with another segment if they are continuous (end pressure of self matches start pressure of other).
+  - `is_pressure_continuous_with(self, other: DiveSegment) -> bool`  — End pressure of self matches start pressure of other.
+  - `is_gas_continuous_with(self, other: DiveSegment) -> bool`  — Same gas on both segments (Nones treated as unknown — not continuous).
+  - `is_rate_continuous_with(self, other: DiveSegment) -> bool`  — Same pressure rate across the boundary — segments form an unbroken linear traverse.
+  - `is_continuous_with(self, other: DiveSegment, *, check_gas: bool = False, check_rate: bool = False) -> bool`  — Pressure-continuous by default.
+  - `is_fully_continuous_with(self, other: DiveSegment) -> bool`  — Convenience — checks pressure, gas, and rate together.
+  - `iter_pressures(self, interval: timedelta, *, include_end: bool = True) -> Iterator[tuple[timedelta, Pressure]]`  — Yield (elapsed, pressure) at each interval through the segment.
+  - `to_dict(self) -> dict[str, Any]`  — Serialize to a JSON-compatible dict.
+  - @classmethod `from_dict(cls, data: Mapping[str, Any]) -> DiveSegment`  — Reconstruct a DiveSegment from :meth:`to_dict` output.
+  - `to_json(self, indent: int | None = None) -> str`  — Serialize to a JSON string.
+  - @classmethod `from_json(cls, data: str) -> DiveSegment`  — Reconstruct a DiveSegment from a JSON string (see :meth:`from_dict`).
+  attrs: `start_pressure: Pressure; end_pressure: Pressure; duration: timedelta; gas: Gas; kind: SegmentKind.Members`
+  dunders: `__delattr__, __eq__, __hash__, __repr__, __setattr__, __str__`
+
+## `src/diveplan/core/gas.py`
+Gas mix value object for diveplan.
+`__all__ = ['Gas']`
+### class `Gas` — Immutable O2/He/N2 breathing gas mixture.
+  `__slots__ = ('_fo2', '_fhe', '_fn2')`
+  - `__init__(self, fo2: float, fhe: float = 0.0) -> None`
+  - @property `fo2(self) -> float`  — Oxygen fraction (0.0-1.0).
+  - @property `fhe(self) -> float`  — Helium fraction (0.0-1.0).
+  - @property `fn2(self) -> float`  — Nitrogen fraction (0.0-1.0), derived as ``1 - fo2 - fhe``.
+  - @property `name(self) -> str`  — Human-readable name for this gas, e.g. "Air", "EAN32", "TX21/35".
+  - @classmethod `air(cls) -> Gas`  — Return standard air (21 % O2, 79 % N2).
+  - @classmethod `oxygen(cls) -> Gas`  — Return 100 % oxygen.
+  - @classmethod `nitrox(cls, fo2: float) -> Gas`  — Return a nitrox (O2/N2) mix with the given O2 fraction.
+  - @classmethod `ean(cls, fo2: float) -> Gas`  — Alias for :meth:`nitrox`.
+  - @classmethod `trimix(cls, fo2: float, fhe: float) -> Gas`  — Return a trimix (O2/He/N2) gas.
+  - @classmethod `from_name(cls, name: str) -> Gas`  — Parse a gas mix from a human-readable name string.
+  - `ppo2(self, pressure: Pressure) -> Pressure`  — Return the partial pressure of O2 at the given ambient pressure.
+  - `pphe(self, pressure: Pressure) -> Pressure`  — Return the partial pressure of He at the given ambient pressure.
+  - `ppn2(self, pressure: Pressure) -> Pressure`  — Return the partial pressure of N2 at the given ambient pressure.
+  - `mod(self, *, ppo2_bar: float) -> Pressure`  — Return the maximum operating depth (MOD) for a given ppO2 limit.
+  - `end(self, pressure: Pressure) -> Pressure`  — Return the equivalent narcotic depth (END) at the given pressure.
+  - `best_mix(self, depth: float | Pressure, *, trimix: bool = False, hypoxic: bool = False) -> Gas`  — Return the optimal gas mix for the given depth.
+  dunders: `__eq__, __hash__, __repr__, __setattr__, __str__`
+
+## `src/diveplan/core/pressure.py`
+core/pressure.py — Pressure value type.
+`__all__ = ['Pressure', 'PressureUnit']`
+- const `PressureUnit = Literal['bar', 'mbar', 'atm', 'psi', 'm', 'ft']`
+### class `Pressure` — Absolute pressure stored as integer millibar.
+  `__slots__ = ('_mbar',)`
+  - `__init__(self, mbar: int) -> None`
+  - @classmethod `from_bar(cls, bar: float) -> Pressure`  — Construct from bar. Rounds to nearest mbar.
+  - @classmethod `from_mbar(cls, mbar: float) -> Pressure`  — Construct from float mbar. Rounds to nearest integer mbar.
+  - @classmethod `from_depth_m(cls, depth_m: float) -> Pressure`  — Construct from depth in metres using the current DiveConfig environment.
+  - @classmethod `from_atm(cls, atm: float) -> Pressure`  — Construct from atmospheres. Rounds to nearest mbar.
+  - @classmethod `from_psi(cls, psi: float) -> Pressure`  — Construct from psi. Rounds to nearest mbar.
+  - @classmethod `from_depth_ft(cls, depth_ft: float) -> Pressure`  — Construct from depth in feet using the current DiveConfig environment.
+  - @classmethod `surface(cls) -> Pressure`  — Convenience constructor for surface pressure in the current DiveConfig environment.
+  - @classmethod `from_str(cls, s: str) -> Pressure`  — Parse a pressure from a string with unit suffix. Supported formats:
+  - @property `mbar(self) -> int`  — Absolute pressure in integer millibar (the ground-truth value).
+  - @property `bar(self) -> float`  — Absolute pressure in bar.
+  - @property `depth_m(self) -> float`  — Depth in metres in the context of the current DiveConfig environment.
+  - @property `depth_ft(self) -> float`  — Depth in feet in the context of the current DiveConfig environment.
+  - @property `atm(self) -> float`  — Absolute pressure in atmospheres, relative to the current surface pressure.
+  - @property `psi(self) -> float`  — Absolute pressure in pounds per square inch.
+  - @property `is_surface(self) -> bool`
+  - `to_str(self, unit: PressureUnit = 'bar') -> str`  — Format pressure as a string in the specified unit.
+  attrs: `_PSI_PER_MBAR = 0.0145038`
+  dunders: `__add__, __delattr__, __eq__, __ge__, __gt__, __hash__, __le__, __lt__, __mul__, __repr__, __rmul__, __setattr__, __str__, __sub__, __truediv__, __truediv__, __truediv__`
+
+## `src/diveplan/dive/__init__.py`
+(empty stub)
+
+## `src/diveplan/dive/dive_profile.py`
+`__all__ = ('DiveProfile', 'ProfileValidationError', 'ProfileContinuityError', 'ProfileSimplicityError', 'ProfileStartEndError', 'ProfileDepthContinuityError', 'ProfileGasContinuityError', 'ProfileEmptyError', 'ProfileTooShortError', 'ProfileBuilderPolicy')`
+### class `ProfileValidationError` (ValueError) — Base descriptor for a dive profile validation problem.
+  - `__init__(self, message: str, *, segment_index: Optional[int] = None, segments: tuple[DiveSegment, ...] = ())`
+  attrs: `fixable: bool = False`
+### class `ProfileEmptyError` (ProfileValidationError) — The profile has no segments. Not auto-fixable.
+  - `__init__(self) -> None`
+  attrs: `fixable = False`
+### class `ProfileTooShortError` (ProfileValidationError) — The profile has fewer than 2 segments (surface → dive → surface). Not auto-fixable.
+  - `__init__(self, segment_count: int) -> None`
+  attrs: `fixable = False`
+### class `ProfileStartEndError` (ProfileValidationError) — The profile does not start and end at the surface. Fixable via add_surface_segments().
+  - `__init__(self, first_segment: DiveSegment, last_segment: DiveSegment) -> None`
+  attrs: `fixable = True`
+### class `ProfileContinuityError` (ProfileValidationError) — Base for problems at the seam between two adjacent segments.
+  - `__init__(self, message: str, segment_index: int, segment_a: DiveSegment, segment_b: DiveSegment)`
+  attrs: `segment_index: int`
+### class `ProfileDepthContinuityError` (ProfileContinuityError) — The end pressure of one segment does not match the start of the next. Fixable via a transition segment.
+  - `__init__(self, segment_index: int, segment_a: DiveSegment, segment_b: DiveSegment) -> None`
+  attrs: `fixable = True`
+### class `ProfileGasContinuityError` (ProfileContinuityError) — Adjacent segments use different gases without a gas switch. Fixable via a gas switch segment.
+  - `__init__(self, segment_index: int, segment_a: DiveSegment, segment_b: DiveSegment) -> None`
+  attrs: `fixable = True`
+### class `ProfileSimplicityError` (ProfileContinuityError) — Adjacent segments are fully continuous and could be merged. Fixable via merge.
+  - `__init__(self, segment_index: int, segment_a: DiveSegment, segment_b: DiveSegment) -> None`
+  attrs: `fixable = True`
+### class `ProfileBuilderPolicy` (Enum) — Policies for handling validation during dive profile construction.
+  attrs: `RAISE_BAD_PROFILE = auto(); ALLOW_BAD_PROFILE = auto(); AUTOFIX_BAD_PROFILE = auto()`
+- `_as_timedelta(value: timedelta | float) -> timedelta`  — Coerce a time argument: timedelta as-is, bare numbers as minutes
+### class `DiveProfile` — A dive profile consisting of a sequence of dive segments.
+  `__slots__ = ('_segments', '_builder_policy')`
+  - `__init__(self, builder_policy: ProfileBuilderPolicy = ProfileBuilderPolicy.RAISE_BAD_PROFILE)`  — Initialize a new DiveProfile.
+  - @property `builder_policy(self) -> ProfileBuilderPolicy`  — The active profile builder policy.
+  - `copy(self, *, override_policy: Optional[ProfileBuilderPolicy] = None) -> DiveProfile`  — Create a copy of the dive profile.
+  - `_get_last_pressure(self) -> Pressure`  — Current position — the end pressure of the last segment, or surface if empty.
+  - `_get_last_gas(self) -> Gas`  — Get the gas of the last segment, or air if empty.
+  - @property `segments(self) -> list[DiveSegment]`  — The list of segments in the profile.
+  - @property `segment_count(self) -> int`  — The number of segments in the profile.
+  - @property `runtime(self) -> timedelta`  — Total duration of the profile (sum of all segment durations).
+  - `start_time_of_segment(self, index: int) -> timedelta`  — Elapsed runtime at which the segment at `index` begins.
+  - `segment_index_at(self, t: timedelta | float) -> int`  — Index of the segment active at runtime `t` (minutes or timedelta).
+  - `segment_at(self, t: timedelta | float) -> DiveSegment`  — The segment active at runtime `t` (minutes or timedelta).
+  - `pressure_at(self, t: timedelta | float) -> Pressure`  — Ambient pressure at runtime `t` (minutes or timedelta), interpolated
+  - `gas_at(self, t: timedelta | float) -> Gas`  — Breathing gas at runtime `t` (minutes or timedelta).
+  - @staticmethod `_is_gas_switch_seam(a: DiveSegment, b: DiveSegment) -> bool`  — A seam is a legitimate gas switch if either side is a GAS_SWITCH segment.
+  - `_seam_error(self, a: DiveSegment, b: DiveSegment, index: int) -> Optional[ProfileValidationError]`  — Return the most fundamental continuity error at the seam (a → b), or None.
+  - `_raise_on_seam(self, a: DiveSegment, b: DiveSegment, index: int) -> None`  — Under RAISE policy, raise the seam error (a → b) if there is one.
+  - `_check_insertion(self, index: int, segment: DiveSegment) -> None`  — Under RAISE policy, validate the seam(s) a new segment at `index` would create.
+  - `_autofix(self) -> None`  — Under AUTOFIX policy, insert transitions and gas switches.
+  - `add_segment(self, segment: DiveSegment) -> DiveProfile`  — Append a segment to the profile.
+  - `add_segments(self, segments: list[DiveSegment]) -> DiveProfile`  — Append multiple segments to the profile (each via add_segment).
+  - `remove_segment_at_index(self, index: int) -> DiveProfile`  — Remove a segment at a specific index.
+  - `remove_segment_at_indices(self, indices: list[int]) -> DiveProfile`  — Remove multiple segments at specific indices.
+  - `remove_segment(self, segment: DiveSegment) -> DiveProfile`  — Remove a segment by value.
+  - `remove_segments(self, segments: list[DiveSegment]) -> DiveProfile`  — Remove multiple segments by value.
+  - `remove_last_segment(self) -> DiveProfile`  — Remove the final segment from the profile.
+  - `clear_profile(self) -> DiveProfile`  — Clear all segments from the profile.
+  - `insert_segment_at_index(self, index: int, segment: DiveSegment) -> DiveProfile`  — Insert a segment at a specific index.
+  - `insert_segments_at_index(self, index: int, segments: list[DiveSegment]) -> DiveProfile`  — Insert multiple segments at a specific index, in order.
+  - `replace_segment_at_index(self, index: int, segment: DiveSegment) -> DiveProfile`  — Replace a segment at a specific index.
+  - `get_segment(self, index: int) -> DiveSegment`  — Retrieve a segment by its index.
+  - `get_last_segment(self) -> DiveSegment`  — Get the last segment in the profile.
+  - `get_first_segment(self) -> DiveSegment`  — Get the first segment in the profile.
+  - `get_segment_index(self, segment: DiveSegment) -> int`  — Find the index of a specific segment.
+  - `descend_to(self, depth: Pressure | str | float, *, rate: Optional[float] = None, gas: Gas | str | None = None) -> DiveProfile`  — Append a descent from the current position to `depth`.
+  - `ascend_to(self, depth: Pressure | str | float, *, rate: Optional[float] = None, gas: Gas | str | None = None, kind: SegmentKind.Ascent = SegmentKind.ASCENT) -> DiveProfile`  — Append an ascent from the current position to `depth`.
+  - `stay(self, duration: timedelta | float, *, gas: Gas | str | None = None, kind: SegmentKind.Constant = SegmentKind.CONSTANT) -> DiveProfile`  — Append a constant-depth segment at the current position.
+  - `switch_gas(self, gas: Gas | str) -> DiveProfile`  — Append a gas switch at the current position.
+  - `surface(self) -> DiveProfile`  — Append an ascent from the current position to the surface at the
+  - @property `is_valid(self) -> bool`  — Whether the profile is continuous and gas-continuous.
+  - `validate_profile(self, *, skip_simplicity: bool = False, skip_start_end_segments: bool = True) -> tuple[ProfileValidationError, ...]`  — Validate the whole profile and return all problems found.
+  - `fix(self, error: ProfileValidationError) -> DiveProfile`  — Apply the canonical repair for a single validation error.
+  - `fix_all(self) -> DiveProfile`  — Repeatedly validate and repair until no fixable error remains.
+  - @staticmethod `make_transition_segment(segment_a: DiveSegment, segment_b: DiveSegment) -> DiveSegment`  — Create a segment bridging a pressure gap between two segments.
+  - @staticmethod `make_gas_switch_segment(segment_a: DiveSegment, segment_b: DiveSegment) -> DiveSegment`  — Create a gas switch segment between two pressure-continuous segments.
+  - `simplify_profile(self) -> DiveProfile`  — Merge fully continuous adjacent segments to simplify the profile.
+  - `fix_continuity(self) -> DiveProfile`  — Insert transition segments to resolve pressure discontinuities (in place).
+  - `fix_gas_continuity(self) -> DiveProfile`  — Insert gas switch segments to resolve gas discontinuities (in place).
+  - `add_start_surface_segment(self) -> DiveProfile`  — Ensure the profile starts with a descent from the surface.
+  - `add_end_surface_segment(self) -> DiveProfile`  — Ensure the profile ends with an ascent to the surface.
+  - `add_surface_segments(self) -> DiveProfile`  — Ensure the profile both starts and ends at the surface.
+  - `to_dict(self) -> dict[str, Any]`  — Serialize to a JSON-compatible dict (builder policy + segments).
+  - @classmethod `from_dict(cls, data: Mapping[str, Any]) -> DiveProfile`  — Reconstruct a DiveProfile from :meth:`to_dict` output.
+  - `to_json(self, path: Optional[str] = None, indent: int = 2) -> str`  — Serialize to a JSON string, optionally writing to a file.
+  - @classmethod `from_json(cls, data: Optional[str] = None, path: Optional[str] = None) -> DiveProfile`  — Deserialize from a JSON string or file path (see :meth:`from_dict`).
+
+## `src/diveplan/dive/dive_report.py`
+(empty stub)
+
+## `src/diveplan/dive/formatters/__init__.py`
+(empty stub)
+
+## `src/diveplan/models/__init__.py`
+(empty stub)
+
+## `src/diveplan/models/base.py`
+Decompression model base classes.
+`__all__ = ['BaseDecoModel', 'DecoState']`
+### class `DecoState` — Base class for model-specific decompression state snapshots.
+  `__slots__ = ()`
+### class `BaseDecoModel[StateT: DecoState]` (ABC) — Base class for all decompression models.
+  `__slots__ = ('sample_rate_seconds',)`
+  - @abstract `__init__(self) -> None`  — Initialize the decompression model.
+  - `integrate_segment(self, segment: DiveSegment) -> StateT`  — Integrate a dive segment into the model and return the state after it.
+  - @abstract `_integrate_model(self, pressure: Pressure, gas: Gas, dt: timedelta) -> None`  — Advance the model by dt at the given ambient pressure and gas.
+  - @abstract `_get_deco_state(self) -> StateT`  — Snapshot the current model state.
+  - @abstract `get_ceiling(self) -> Pressure`  — Return the current ceiling depth.
+  attrs: `NAME: ClassVar[str]`
+
+## `src/diveplan/models/buhlmann/__init__.py`
+(empty stub)
+
+## `src/diveplan/models/buhlmann/common.py`
+`__all__ = ('Gradient', 'Compartment')`
+### class `Gradient` — Helper for computing gradients of dive segments.
+  `__slots__ = ('gf_low', 'gf_high')`
+  - `__init__(self, gf_low: float, gf_high: float)`
+  - `factor(self, depth_pressure: Pressure, max_depth_pressure: Pressure) -> float`  — Linearly interpolate the gradient for a given depth.
+  attrs: `gf_low: float; gf_high: float`
+  dunders: `__eq__, __hash__, __repr__, __str__`
+### class `Compartment` — Helper for tracking compartment constants and saturation.
+  `__slots__ = ('ppn2', 'pphe', 'ht_n2', 'ht_he', 'a_n2', 'a_he', 'b_n2', 'b_he', 'tolerated_pressure')`
+  - `__init__(self, *, ht_n2: float, ht_he: float, a_n2: float, a_he: float, b_n2: float, b_he: float, ppn2: Optional[Pressure] = None, pphe: Optional[Pressure] = None)`
+  - `update_compartment(self, pressure: Pressure, gas: Gas, duration: timedelta, gradient_factor: float)`
+  - `_integrate_compartment(self, pressure: Pressure, gas: Gas, duration: timedelta)`
+  - `_update_compartment_max_tolerated_pressure(self, ambiant_pressure: Pressure, gradient_factor: float)`
+  - @staticmethod `_calc_inert_gas_pressure(ambiant_pressure: Pressure, inspired_gas_pressure: Pressure, time_minutes: float, half_time_minutes: float) -> Pressure`
+  - @staticmethod `_calcInertGasLimit(ppn2: Pressure, pphe: Pressure, a_n2: float, b_n2: float, a_he: float, b_he: float, ambiant_pressure: Pressure, gradient_factor: float) -> Pressure`
+  - `is_eq_pressures_only(self, other: Compartment) -> bool`
+  - `is_eq_with_pressures(self, other: Compartment) -> bool`
+  attrs: `ppn2: Pressure; pphe: Pressure; ht_n2: float; ht_he: float; a_n2: float; a_he: float; b_n2: float; b_he: float`
+  dunders: `__eq__, __hash__, __repr__, __str__`
+
+## `src/diveplan/planning/__init__.py`
+(empty stub)
+
+## `src/diveplan/planning/ascent_plan.py`
+(empty stub)
+
+## `src/diveplan/planning/gas_plan.py`
+(empty stub)
+
+## `src/diveplan/registry.py`
+### class `PluginNotFoundError` (KeyError)
+  - `__init__(self, name: str, available: list[str]) -> None`
+### class `PluginInvalidError` (TypeError)
+### class `PluginRegistry`
+  - `__init__(self) -> None`
+  - @cached_property `_discovered(self) -> dict[str, type[BaseDecoModel[Any]]]`  — Discovered once from entry points, then frozen.
+  - @property `_all(self) -> dict[str, type[BaseDecoModel[Any]]]`  — Overrides shadow discovered plugins of the same name.
+  - `model(self, name: str) -> type[BaseDecoModel[Any]]`  — Return the plugin class for *name*, or raise PluginNotFoundError.
+  - `all_models(self) -> dict[str, type[BaseDecoModel[Any]]]`  — All registered plugins, keyed by name.
+  - `register_model(self, name: str, cls: type[BaseDecoModel[Any]]) -> None`  — Manually register a plugin class — escape hatch for tests,
+  - `invalidate(self) -> None`  — Force re-discovery on next access.
+- const `registry = PluginRegistry()`
+
+## `src/diveplan/utils/__init__.py`
+(empty stub)
+
+## `src/diveplan/utils/conversions.py`
+`__all__ = ['coerce_depth_to_pressure', 'coerce_gas', 'duration_from_rate', 'DEPTH_TYPES', 'GAS_TYPES']`
+- const `DEPTH_TYPES = float | int | str | Pressure`
+- const `GAS_TYPES = str | Gas`
+- `coerce_depth_to_pressure(value: DEPTH_TYPES) -> Pressure`
+- `coerce_gas(value: GAS_TYPES) -> Gas`
+- `duration_from_rate(rate: float, start_pressure: Pressure, end_pressure: Pressure) -> float`
+
+# Tests (tests/)
+- `conftest.py` (0 tests)
+- `test_config.py` (45 tests) — TestSubConfigBase, TestPhysicsConfig, TestGasConfig, TestDivePlanningConfig, TestDiveConfigStructure, TestGlobalDefault, TestContextManager, TestDefaultConfigLoading, TestSerialization
+- `test_dive_profile.py` (74 tests) — TestDiveProfileBuilder, TestDiveProfileValidation, TestDiveProfileFixes, TestDiveProfileTimeline, TestDiveProfileFluentBuilders, TestDiveProfileSerialization
+- `test_dive_segment.py` (59 tests) — TestDiveSegmentConstruction, TestDiveSegmentProperties, TestDiveSegmentInterpolation, TestDiveSegmentSplitting, TestDiveSegmentMerging, TestDiveSegmentContinuity, TestDiveSegmentIteration, TestDiveSegmentMagicMethods, TestDiveSegmentImmutability, TestDiveSegmentSerialization
+- `test_gas.py` (61 tests) — TestRawConstruction, TestNamedConstructors, TestFromName, TestPartialPressures, TestMod, TestEnd, TestBestMix, TestEqualityAndHash, TestStringRepresentation
+- `test_pressure.py` (70 tests) — TestConstruction, TestProperties, TestAltConstructorsAndProperties, TestStringParsing, TestImmutability, TestAddition, TestSubtraction, TestMultiplication, TestDivision, TestOrdering, TestHashing, TestDisplay

--- a/.claude/generate-index.py
+++ b/.claude/generate-index.py
@@ -1,0 +1,234 @@
+"""Generate .claude/codebase-index.md — a compact API map for token-efficient
+Claude Code sessions.
+
+Extracts module docstring summaries, __all__, class/method/function signatures
+(with annotations and defaults) and docstring first lines via ast. Run from the
+repo root after changing public APIs:
+
+    uv run python .claude/generate-index.py
+"""
+
+from __future__ import annotations
+
+import ast
+from datetime import date
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src" / "diveplan"
+OUT = ROOT / ".claude" / "codebase-index.md"
+
+
+def first_line(doc: str | None) -> str:
+    if not doc:
+        return ""
+    line = doc.strip().splitlines()[0].strip()
+    return line
+
+
+def _sig_str(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
+    a = node.args
+    parts: list[str] = []
+
+    def fmt_arg(arg: ast.arg, default: ast.expr | None) -> str:
+        s = arg.arg
+        if arg.annotation is not None:
+            s += f": {ast.unparse(arg.annotation)}"
+        if default is not None:
+            s += (
+                f" = {ast.unparse(default)}"
+                if arg.annotation
+                else f"={ast.unparse(default)}"
+            )
+        return s
+
+    pos = a.posonlyargs + a.args
+    defaults: list[ast.expr | None] = [None] * (len(pos) - len(a.defaults)) + list(
+        a.defaults
+    )
+    for arg, d in zip(pos, defaults):
+        parts.append(fmt_arg(arg, d))
+    if a.posonlyargs:
+        parts.insert(len(a.posonlyargs), "/")
+    if a.vararg:
+        parts.append("*" + a.vararg.arg)
+    elif a.kwonlyargs:
+        parts.append("*")
+    for arg, d in zip(a.kwonlyargs, a.kw_defaults):
+        parts.append(fmt_arg(arg, d))
+    if a.kwarg:
+        parts.append("**" + a.kwarg.arg)
+
+    sig = f"({', '.join(parts)})"
+    if node.returns is not None:
+        sig += f" -> {ast.unparse(node.returns)}"
+    return sig
+
+
+def decorator_names(
+    node: ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef,
+) -> set[str]:
+    names: set[str] = set()
+    for dec in node.decorator_list:
+        target = dec.func if isinstance(dec, ast.Call) else dec
+        names.add(ast.unparse(target).split(".")[-1])
+    return names
+
+
+def emit_function(
+    node: ast.FunctionDef | ast.AsyncFunctionDef, lines: list[str], indent: str
+) -> None:
+    decs = decorator_names(node)
+    prefix = ""
+    if "property" in decs:
+        prefix = "@property "
+    elif "cached_property" in decs:
+        prefix = "@cached_property "
+    elif "classmethod" in decs:
+        prefix = "@classmethod "
+    elif "staticmethod" in decs:
+        prefix = "@staticmethod "
+    if "abstractmethod" in decs:
+        prefix += "@abstract "
+    doc = first_line(ast.get_docstring(node))
+    doc_part = f"  — {doc}" if doc else ""
+    lines.append(f"{indent}- {prefix}`{node.name}{_sig_str(node)}`{doc_part}")
+
+
+def emit_class(node: ast.ClassDef, lines: list[str], indent: str = "") -> None:
+    bases = ", ".join(ast.unparse(b) for b in node.bases)
+    type_params = (
+        f"[{', '.join(ast.unparse(t) for t in node.type_params)}]"
+        if getattr(node, "type_params", None)
+        else ""
+    )
+    head = (
+        f"{indent}### class `{node.name}{type_params}`"
+        if not indent
+        else f"{indent}- class `{node.name}{type_params}`"
+    )
+    if bases:
+        head += f" ({bases})"
+    doc = first_line(ast.get_docstring(node))
+    if doc:
+        head += f" — {doc}"
+    lines.append(head)
+
+    slots = [
+        s
+        for s in node.body
+        if isinstance(s, ast.Assign)
+        for t in s.targets
+        if isinstance(t, ast.Name) and t.id == "__slots__"
+    ]
+    if slots:
+        lines.append(f"{indent}  `__slots__ = {ast.unparse(slots[0].value)}`")
+
+    enum_members: list[str] = []
+    for item in node.body:
+        if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if item.name.startswith("__") and item.name not in (
+                "__init__",
+                "__enter__",
+                "__exit__",
+            ):
+                # dunders: summarize below instead of listing each
+                continue
+            emit_function(item, lines, indent + "  ")
+        elif isinstance(item, ast.ClassDef):
+            emit_class(item, lines, indent + "  ")
+        elif isinstance(item, ast.Assign):
+            for t in item.targets:
+                if isinstance(t, ast.Name) and not t.id.startswith("__"):
+                    enum_members.append(f"{t.id} = {ast.unparse(item.value)}")
+        elif isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name):
+            name = item.target.id
+            if name.startswith("_") and not name.startswith("__"):
+                continue
+            ann = ast.unparse(item.annotation)
+            val = f" = {ast.unparse(item.value)}" if item.value is not None else ""
+            enum_members.append(f"{name}: {ann}{val}")
+
+    dunders = sorted(
+        item.name
+        for item in node.body
+        if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and item.name.startswith("__")
+        and item.name not in ("__init__", "__enter__", "__exit__")
+    )
+    if enum_members:
+        lines.append(f"{indent}  attrs: `{'; '.join(enum_members)}`")
+    if dunders:
+        lines.append(f"{indent}  dunders: `{', '.join(dunders)}`")
+
+
+def emit_module(path: Path, lines: list[str]) -> None:
+    rel = path.relative_to(ROOT).as_posix()
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    body = tree.body
+
+    lines.append(f"\n## `{rel}`")
+    doc = first_line(ast.get_docstring(tree))
+    if doc:
+        lines.append(f"{doc}")
+
+    for item in body:
+        if isinstance(item, ast.Assign):
+            for t in item.targets:
+                if isinstance(t, ast.Name) and t.id == "__all__":
+                    lines.append(f"`__all__ = {ast.unparse(item.value)}`")
+                elif (
+                    isinstance(t, ast.Name)
+                    and not t.id.startswith("_")
+                    and t.id != "__all__"
+                ):
+                    lines.append(f"- const `{t.id} = {ast.unparse(item.value)}`")
+        elif isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            emit_function(item, lines, "")
+        elif isinstance(item, ast.ClassDef):
+            emit_class(item, lines)
+
+
+def main() -> None:
+    lines: list[str] = [
+        "# diveplan codebase index",
+        "",
+        f"Auto-generated API map (regenerate: `uv run python .claude/generate-index.py`). "
+        f"Generated {date.today().isoformat()}.",
+        "",
+        "Read this instead of source files when you only need signatures/structure. "
+        "Read the actual source before *editing* anything listed here.",
+    ]
+
+    for path in sorted(SRC.rglob("*.py")):
+        if path.stat().st_size == 0:
+            rel = path.relative_to(ROOT).as_posix()
+            lines.append(f"\n## `{rel}`\n(empty stub)")
+            continue
+        emit_module(path, lines)
+
+    # Test files: one line each, class names only.
+    lines.append("\n# Tests (tests/)")
+    for path in sorted((ROOT / "tests").glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        classes = [n.name for n in tree.body if isinstance(n, ast.ClassDef)]
+        n_tests = sum(
+            isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and n.name.startswith("test_")
+            for cls in tree.body
+            if isinstance(cls, ast.ClassDef)
+            for n in cls.body
+        ) + sum(
+            isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and n.name.startswith("test_")
+            for n in tree.body
+        )
+        summary = f" — {', '.join(classes)}" if classes else ""
+        lines.append(f"- `{path.name}` ({n_tests} tests){summary}")
+
+    OUT.write_text("\n".join(lines) + "\n", encoding="utf-8", newline="\n")
+    print(f"wrote {OUT.relative_to(ROOT)} ({len(lines)} lines)")
+
+
+if __name__ == "__main__":
+    main()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,85 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+`diveplan` is a pure-Python library (Python ≥ 3.14) for dive planning and decompression calculation — calculation core only, no UI/CLI. Designed for two use cases that drive every decision: single dive planning and large batch simulations. Experimental software; never soften the README's "do not use for real dives" caution.
+
+## Token-efficient navigation
+
+`.claude/codebase-index.md` is an auto-generated API map of the whole library: every module with class/method/function signatures, docstring one-liners, `__slots__`, and per-file test-class listings. **Read it first instead of reading source files** when you need to know what exists, its signature, or where something lives. Only read actual source before editing it. Regenerate after changing public APIs:
+
+```bash
+uv run python .claude/generate-index.py
+```
+
+## Commands
+
+The project uses [uv](https://docs.astral.sh/uv/); prefix everything with `uv run`.
+
+```bash
+uv sync                                     # create venv + install incl. dev deps
+uv run pytest                               # full test suite
+uv run pytest tests/test_gas.py             # one file
+uv run pytest tests/test_gas.py::TestBestMix::test_air_at_30m   # one test
+uv run ruff check . && uv run ruff format . # lint + format (line length 88)
+uv run mypy src                             # type-check — strict mode is on
+uv run sphinx-build -b html docs/source docs/_build/html   # API docs (furo)
+```
+
+Line endings are LF, enforced via `.gitattributes`.
+
+## Architecture
+
+Layering (imports flow strictly downward; `core/` never imports from upper layers):
+
+```
+core/      Pressure, Gas, DiveSegment, DiveConfig — value objects + config
+dive/      DiveProfile (builder/validation/timeline), reports, formatters
+models/    deco models (BaseDecoModel, DecoState, Bühlmann helpers)
+planning/  ascent planner, gas plan (stubs — in progress)
+registry.py  entry-point plugin discovery for deco models
+```
+
+### Pressure is ground truth
+
+`Pressure` stores integer millibar — never float depth. Exact equality and hashing are meaningful; use them. Two type-discipline rules to preserve:
+
+- `Pressure - Pressure` returns a **signed int mbar delta**, deliberately not a `Pressure` (absolute pressure vs. difference are different quantities).
+- Depth/atm conversions (`from_depth_m`, `.depth_m`, `.surface()`…) read `DiveConfig.current().physics` **at call time** — the same Pressure renders as different depths under different configs. Dependency is one-way: Pressure → DiveConfig, never reversed.
+
+### DiveConfig: one shared, scoped config
+
+Frozen Pydantic root with mutable, validated sub-configs (`physics`, `planning`, `gas`). Access via `DiveConfig.current()`. Overrides are a ContextVar stack (`with cfg:` — nestable, isolated per thread/asyncio task for parallel batch runs) over a process-global default (`set_default()`). Startup default resolves: `DIVEPLAN_CONFIG_FILE` env var → `./diveplan.config.json` → `~/.diveplan/config.json` → factory defaults; `DIVEPLAN_NO_FILE_CONFIG=1` skips files. Validation philosophy: reject only physically impossible values (zero/negative), never operational limits — this is an experimentation platform.
+
+Tests: `tests/conftest.py` has an autouse fixture pinning a fresh factory-default config around every test, so tests may mutate config freely.
+
+### Immutable value objects
+
+`Pressure`, `Gas`, `DiveSegment` are frozen: `__slots__` plus `__setattr__`/`__delattr__` guards, constructed via `object.__setattr__`. Keep it that way — `DiveProfile.copy()` does a shallow list copy on the assumption segments are true values, and segments are hashable. `DiveSegment` duration must be strictly positive except zero-duration `GAS_SWITCH` segments (instant switch).
+
+### DiveProfile: plan is input, results are output
+
+A profile is pure geometry (list of segments). Do **not** hang model results (tissue states, ceilings, TTS) on segments or the profile — results belong in a separate result layer so one profile can be run under multiple models/GFs and compared. This is a deliberate, agreed design constraint.
+
+Key mechanics spread across `dive/dive_profile.py`:
+
+- **Builder policies** (`ProfileBuilderPolicy`): RAISE validates each touched seam O(1) and raises; ALLOW skips validation; AUTOFIX inserts transitions/gas switches after each mutation.
+- **Validation errors are pure data** (`ProfileValidationError` subclasses): descriptors only — no profile reference, no repair logic. Repairs live on `DiveProfile.fix(error)` / `.fix_all()`. Keep this split when adding error types.
+- **Fluent builders** (`descend_to`, `ascend_to`, `stay`, `switch_gas`, `surface`) coerce arguments: depths as `Pressure` | `"40 m"` strings (`Pressure.from_str`) | bare metres; gases as `Gas` | names (`Gas.from_name("ean50")`). They start from the current position (last segment's *end* pressure) and go through `add_segment`, so policies apply.
+- **Timeline methods** (`runtime`, `segment_at(t)`, `pressure_at(t)`, `gas_at(t)`) accept minutes or timedelta. Seam convention: a segment owns `[start, end)`; the final segment also owns `t == runtime`; at a gas-switch boundary the *new* gas is reported.
+- **Serialization** (`to_dict`/`from_dict`/`to_json`/`from_json`) round-trips without re-validating — a stored in-progress (discontinuous) profile must load as saved.
+
+### Deco models and plugins
+
+`BaseDecoModel[StateT: DecoState]` (PEP 695 generics): each model defines its own immutable `DecoState` subclass and returns typed state, not dicts. State snapshots are the currency for future checkpointing and counterfactual queries (TTS at time t) — keep them cheap to copy.
+
+Plugin discovery: entry-point group **`diveplan.deco_models`** (single source of truth: `_ENTRY_POINT_GROUP` in `registry.py`). The registry eagerly loads *every* entry point in the group on first access, so never register an entry point in `pyproject.toml` before its module exists — one dangling reference breaks all model lookups. The `zhl16c` and formatter entry points are commented out in `pyproject.toml` until their modules land; `DiveConfig.planning.default_model` defaults to `"zhl16c"`, so uncomment the entry point in the same PR that adds `zhl16.py`. `registry.register_model()` is the manual escape hatch for tests.
+
+### Known state / gotchas
+
+- `models/buhlmann/common.py` is in-progress and has known issues: `Gradient.factor` is inverted vs. standard gradient-factor convention (GF-low belongs at the deepest stop, GF-high at surface) and interpolates on absolute-pressure ratio; it also fails strict mypy. Fix before building the ascent planner on it.
+- `planning/` and `dive/dive_report.py` are empty stubs.
+- `diveplan_roadmap.md` predates implementation and drifts from the code in places (e.g. `DiveStep`/`AbstractDecoModel` naming — the code's `DiveSegment`/`BaseDecoModel` won); trust the code.
+- `__init__.py` re-exports core types and a `diveconfig` proxy; planning/dive/report symbols get re-exported there as layers land.

--- a/README.md
+++ b/README.md
@@ -74,24 +74,38 @@ with fresh:
     Pressure.from_depth_m(30).bar     # uses fresh-water density
 ```
 
-Building a profile:
+Building a profile — fluent style, with depths as `"40 m"` strings and gases
+by name:
 
 ```python
-from diveplan import DiveSegment, Gas, Pressure
 from diveplan.dive.dive_profile import DiveProfile
 
-profile = DiveProfile()
-profile.add_segment(
-    DiveSegment(Pressure.surface(), Pressure.from_depth_m(40), 4, Gas.air())
-)
-profile.add_segment(
-    DiveSegment(Pressure.from_depth_m(40), Pressure.from_depth_m(40), 20, Gas.air())
+profile = (
+    DiveProfile()
+    .descend_to("40 m")        # air by default, configured descent rate
+    .stay(20)                  # 20 min bottom time
+    .ascend_to("21 m")
+    .switch_gas("ean50")       # gas switch at the configured switch time
+    .surface()                 # ascend to the surface
 )
 
-# Validate and auto-repair (insert transitions, gas switches, surface segments).
+# Address the profile by runtime:
+profile.runtime                # total timedelta
+profile.pressure_at(23).depth_m   # depth 23 minutes into the dive
+profile.gas_at(23)                # gas breathed at that moment
+
+# JSON round-trip:
+profile.to_json(path="dive.json")
+restored = DiveProfile.from_json(path="dive.json")
+```
+
+Segments can still be added explicitly (`add_segment`, `insert_segment_at_index`,
+…) and repaired after the fact:
+
+```python
 for error in profile.validate_profile(skip_start_end_segments=False):
     print(error.message)
-profile.fix_all()
+profile.fix_all()   # insert transitions, gas switches, surface segments
 ```
 
 ## Configuration

--- a/diveplan_roadmap.md
+++ b/diveplan_roadmap.md
@@ -403,7 +403,7 @@ Plugins register via Python entry points in their own `pyproject.toml`:
 
 ```toml
 # diveplan-vpm/pyproject.toml
-[project.entry-points."diveplan.models"]
+[project.entry-points."diveplan.deco_models"]
 vpm = "diveplan_vpm:VPMModel"
 
 [project.entry-points."diveplan.formatters"]
@@ -422,7 +422,7 @@ registry.register_model("exp", MyModel)     # manual escape hatch
 
 Built-in models and formatters self-register via `diveplan`'s own `pyproject.toml`.
 
-**Plugin groups:** `diveplan.models`, `diveplan.formatters`
+**Plugin groups:** `diveplan.deco_models`, `diveplan.formatters`
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,12 +19,19 @@ dependencies = [
 [project.optional-dependencies]
 dev = ["pytest", "pytest-cov", "ruff", "mypy"]
 
-[project.entry-points."diveplan.models"]
-zhl16c = "diveplan.models.buhlmann.zhl16:ZHL16C"
-
-[project.entry-points."diveplan.formatters"]
-json = "diveplan.dive.formatters.json:JSONFormatter"
-csv = "diveplan.dive.formatters.csv:CSVFormatter"
+# Deco models are discovered from the "diveplan.deco_models" entry-point group
+# (see src/diveplan/registry.py). The registry eagerly loads every entry point
+# in the group, so an entry must only be registered once its module exists —
+# a dangling reference would break all model lookups.
+#
+# Uncomment when diveplan/models/buhlmann/zhl16.py lands:
+# [project.entry-points."diveplan.deco_models"]
+# zhl16c = "diveplan.models.buhlmann.zhl16:ZHL16C"
+#
+# Uncomment when the formatter modules land:
+# [project.entry-points."diveplan.formatters"]
+# json = "diveplan.dive.formatters.json:JSONFormatter"
+# csv = "diveplan.dive.formatters.csv:CSVFormatter"
 
 [tool.ruff]
 line-length = 88

--- a/src/diveplan/core/dive_segment.py
+++ b/src/diveplan/core/dive_segment.py
@@ -1,7 +1,9 @@
+import json
 import math
+from collections.abc import Mapping
 from datetime import timedelta
 from enum import Enum, auto
-from typing import Iterator
+from typing import Any, Iterator
 
 from diveplan.core.gas import Gas
 from diveplan.core.pressure import Pressure
@@ -40,6 +42,22 @@ class SegmentKind:
 
     # Union of all possible segment kinds for type annotations
     Members = Descent | Ascent | Constant
+
+    @staticmethod
+    def from_name(name: str) -> SegmentKind.Members:
+        """Look up a segment kind by member name, e.g. ``"DESCENT"``, ``"STOP"``.
+
+        Member names are unique across the Descent/Ascent/Constant sub-enums,
+        so a bare name is unambiguous. Used by DiveSegment deserialization.
+
+        Raises:
+            ValueError: If no segment kind has that name.
+        """
+        key = name.strip().upper()
+        for enum_cls in (SegmentKind.Descent, SegmentKind.Ascent, SegmentKind.Constant):
+            if key in enum_cls.__members__:
+                return enum_cls[key]
+        raise ValueError(f"Unknown segment kind name: {name!r}")
 
 
 class DiveSegment:
@@ -85,15 +103,21 @@ class DiveSegment:
                 duration (an instant switch, gas_switch_minutes = 0).
         """
 
-        self.start_pressure = start_pressure
-        self.end_pressure = end_pressure
+        object.__setattr__(self, "start_pressure", start_pressure)
+        object.__setattr__(self, "end_pressure", end_pressure)
 
-        self.duration = (
-            duration if isinstance(duration, timedelta) else timedelta(minutes=duration)
+        object.__setattr__(
+            self,
+            "duration",
+            duration
+            if isinstance(duration, timedelta)
+            else timedelta(minutes=duration),
         )
 
-        self.gas = gas
-        self.kind = self._determine_kind(ascent_kind, constant_kind)
+        object.__setattr__(self, "gas", gas)
+        object.__setattr__(
+            self, "kind", self._determine_kind(ascent_kind, constant_kind)
+        )
 
         if self.duration < timedelta(0):
             raise ValueError(
@@ -107,6 +131,18 @@ class DiveSegment:
                 f"DiveSegment duration must be strictly positive, got {self.duration}. "
                 "Only a gas switch (constant depth) may have zero duration."
             )
+
+    # ------------------------------------------------------------------
+    # Immutability guard
+    # ------------------------------------------------------------------
+
+    def __setattr__(self, name: str, value: object) -> None:
+        raise AttributeError(
+            "DiveSegment is immutable — create a new instance instead."
+        )
+
+    def __delattr__(self, name: str) -> None:
+        raise AttributeError("DiveSegment is immutable.")
 
     def _determine_kind(
         self,
@@ -385,4 +421,60 @@ class DiveSegment:
             f"over {self.duration.total_seconds() / 60:.1f} minutes, breathing {self.gas.name}"
         )
 
-    # TODO: to_dict, from_dict, to_json, from_json, etc.
+    # -------------------------------------------------------------------
+    # Serialization
+    # -------------------------------------------------------------------
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict.
+
+        Pressures are stored as integer mbar (the ground truth), duration in
+        seconds, and the kind by its member name.
+        """
+        return {
+            "start_pressure_mbar": self.start_pressure.mbar,
+            "end_pressure_mbar": self.end_pressure.mbar,
+            "duration_s": self.duration.total_seconds(),
+            "gas": {"fo2": self.gas.fo2, "fhe": self.gas.fhe},
+            "kind": self.kind.name,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> DiveSegment:
+        """Reconstruct a DiveSegment from :meth:`to_dict` output.
+
+        Raises:
+            ValueError: If the stored kind contradicts the pressure geometry
+                (e.g. kind "DESCENT" but start pressure >= end pressure), or
+                the kind name is unknown.
+            KeyError: If a required field is missing.
+        """
+        kind = SegmentKind.from_name(data["kind"])
+        segment = cls(
+            start_pressure=Pressure(data["start_pressure_mbar"]),
+            end_pressure=Pressure(data["end_pressure_mbar"]),
+            duration=timedelta(seconds=data["duration_s"]),
+            gas=Gas(data["gas"]["fo2"], fhe=data["gas"].get("fhe", 0.0)),
+            ascent_kind=kind
+            if isinstance(kind, SegmentKind.Ascent)
+            else SegmentKind.ASCENT,
+            constant_kind=kind
+            if isinstance(kind, SegmentKind.Constant)
+            else SegmentKind.CONSTANT,
+        )
+        if segment.kind is not kind:
+            raise ValueError(
+                f"Stored kind {kind.name} contradicts pressure geometry "
+                f"({segment.start_pressure} → {segment.end_pressure} "
+                f"determines {segment.kind.name})."
+            )
+        return segment
+
+    def to_json(self, indent: int | None = None) -> str:
+        """Serialize to a JSON string."""
+        return json.dumps(self.to_dict(), indent=indent)
+
+    @classmethod
+    def from_json(cls, data: str) -> DiveSegment:
+        """Reconstruct a DiveSegment from a JSON string (see :meth:`from_dict`)."""
+        return cls.from_dict(json.loads(data))

--- a/src/diveplan/core/pressure.py
+++ b/src/diveplan/core/pressure.py
@@ -19,11 +19,14 @@ Depth conversion:
 Dependency: Pressure -> DiveConfig (one way only, never reversed).
 """
 
-from typing import overload
+from typing import Literal, overload
 
 from diveplan.core.config import DiveConfig
 
-__all__ = ["Pressure"]
+__all__ = ["Pressure", "PressureUnit"]
+
+PressureUnit = Literal["bar", "mbar", "atm", "psi", "m", "ft"]
+"""Unit names accepted by :meth:`Pressure.to_str`."""
 
 
 class Pressure:
@@ -340,23 +343,23 @@ class Pressure:
     # Display
     # ------------------------------------------------------------------
 
-    def to_str(self, unit: str = "bar") -> str:
+    def to_str(self, unit: PressureUnit = "bar") -> str:
         """Format pressure as a string in the specified unit.
 
         Supported units: 'bar', 'mbar', 'atm', 'psi', 'm' (depth in metres), 'ft' (depth in feet).
         """
-        unit = unit.lower()
-        if unit == "bar":
+        u = unit.lower()
+        if u == "bar":
             return f"{self.bar:.3f} bar"
-        elif unit == "mbar":
+        elif u == "mbar":
             return f"{self.mbar} mbar"
-        elif unit == "atm":
+        elif u == "atm":
             return f"{self.atm:.3f} atm"
-        elif unit == "psi":
+        elif u == "psi":
             return f"{self.psi:.2f} psi"
-        elif unit == "m":
+        elif u == "m":
             return f"{self.depth_m:.1f} m"
-        elif unit == "ft":
+        elif u == "ft":
             return f"{self.depth_ft:.1f} ft"
         else:
             raise ValueError(

--- a/src/diveplan/dive/dive_profile.py
+++ b/src/diveplan/dive/dive_profile.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+import json
+from collections.abc import Mapping
+from datetime import timedelta
 from enum import Enum, auto
-from typing import Optional
+from typing import Any, Optional
 
 from ..core.config import DiveConfig
 from ..core.dive_segment import DiveSegment, SegmentKind
 from ..core.gas import Gas
 from ..core.pressure import Pressure
+from ..utils.conversions import coerce_depth_to_pressure, coerce_gas
 
 __all__ = (
     "DiveProfile",
@@ -90,9 +94,7 @@ class ProfileStartEndError(ProfileValidationError):
 
     fixable = True
 
-    def __init__(
-        self, first_segment: DiveSegment, last_segment: DiveSegment
-    ) -> None:
+    def __init__(self, first_segment: DiveSegment, last_segment: DiveSegment) -> None:
         super().__init__(
             f"Dive profile must start and end at the surface, but starts with "
             f"{first_segment} and ends with {last_segment}. "
@@ -200,6 +202,23 @@ class ProfileBuilderPolicy(Enum):
 
 
 # ------------------------------------------------------------------
+# Argument coercion helpers (fluent builder + timeline ergonomics)
+# ------------------------------------------------------------------
+
+# Depth/gas coercion is shared with the rest of the library.
+_as_pressure = coerce_depth_to_pressure
+_as_gas = coerce_gas
+
+
+def _as_timedelta(value: timedelta | float) -> timedelta:
+    """Coerce a time argument: timedelta as-is, bare numbers as minutes
+    (matching the DiveSegment duration convention)."""
+    if isinstance(value, timedelta):
+        return value
+    return timedelta(minutes=value)
+
+
+# ------------------------------------------------------------------
 # Dive Profile
 # ------------------------------------------------------------------
 class DiveProfile:
@@ -261,10 +280,10 @@ class DiveProfile:
         return new_profile
 
     def _get_last_pressure(self) -> Pressure:
-        """Get the starting pressure of the last segment, or surface pressure if empty."""
+        """Current position — the end pressure of the last segment, or surface if empty."""
         if not self._segments:
             return Pressure.surface()
-        return self.get_segment(-1).start_pressure
+        return self.get_segment(-1).end_pressure
 
     def _get_last_gas(self) -> Gas:
         """Get the gas of the last segment, or air if empty."""
@@ -281,6 +300,80 @@ class DiveProfile:
     def segment_count(self) -> int:
         """The number of segments in the profile."""
         return len(self._segments)
+
+    # ------------------------------------------------------------------
+    # Timeline — address the profile by runtime instead of segment index
+    # ------------------------------------------------------------------
+    # Convention: a segment owns the half-open interval [start, end) of the
+    # global timeline; the final segment additionally owns its end instant
+    # (t == runtime). At a seam this resolves to the *later* segment, so
+    # gas_at() at a gas-switch boundary reports the new gas. Zero-duration
+    # segments (instant gas switches) own no interval and are skipped.
+
+    @property
+    def runtime(self) -> timedelta:
+        """Total duration of the profile (sum of all segment durations)."""
+        return sum((s.duration for s in self._segments), timedelta(0))
+
+    def start_time_of_segment(self, index: int) -> timedelta:
+        """Elapsed runtime at which the segment at `index` begins.
+
+        Raises:
+            IndexError: If the index is out of range.
+        """
+        n = len(self._segments)
+        pos = index if index >= 0 else n + index
+        if not 0 <= pos < n:
+            raise IndexError(
+                f"Segment index {index} is out of range for dive profile with "
+                f"{n} segments."
+            )
+        return sum((s.duration for s in self._segments[:pos]), timedelta(0))
+
+    def segment_index_at(self, t: timedelta | float) -> int:
+        """Index of the segment active at runtime `t` (minutes or timedelta).
+
+        Raises:
+            ProfileEmptyError: If the profile has no segments.
+            ValueError: If `t` is negative or beyond the total runtime.
+        """
+        if not self._segments:
+            raise ProfileEmptyError()
+
+        t = _as_timedelta(t)
+        if t < timedelta(0):
+            raise ValueError(f"t={t} is negative.")
+
+        elapsed = timedelta(0)
+        for i, segment in enumerate(self._segments):
+            end = elapsed + segment.duration
+            if t < end:
+                return i
+            elapsed = end
+
+        if t == elapsed:  # t == runtime → owned by the final segment
+            return len(self._segments) - 1
+        raise ValueError(f"t={t} is beyond the profile runtime {elapsed}.")
+
+    def segment_at(self, t: timedelta | float) -> DiveSegment:
+        """The segment active at runtime `t` (minutes or timedelta)."""
+        return self._segments[self.segment_index_at(t)]
+
+    def pressure_at(self, t: timedelta | float) -> Pressure:
+        """Ambient pressure at runtime `t` (minutes or timedelta), interpolated
+        linearly within the active segment."""
+        index = self.segment_index_at(t)
+        segment = self._segments[index]
+        # A zero-duration segment (instant gas switch) is a single instant at
+        # constant depth — interpolation would divide by zero.
+        if segment.duration == timedelta(0):
+            return segment.start_pressure
+        offset = _as_timedelta(t) - self.start_time_of_segment(index)
+        return segment.pressure_at_time(offset)
+
+    def gas_at(self, t: timedelta | float) -> Gas:
+        """Breathing gas at runtime `t` (minutes or timedelta)."""
+        return self.segment_at(t).gas
 
     # ------------------------------------------------------------------
     # Seam helpers — local (O(1)) validation between two adjacent segments
@@ -345,9 +438,7 @@ class DiveProfile:
             self._builder_policy is ProfileBuilderPolicy.RAISE_BAD_PROFILE
             and self._segments
         ):
-            self._raise_on_seam(
-                self._segments[-1], segment, len(self._segments) - 1
-            )
+            self._raise_on_seam(self._segments[-1], segment, len(self._segments) - 1)
 
         self._segments.append(segment)
         self._autofix()
@@ -490,6 +581,142 @@ class DiveProfile:
         return self._segments.index(segment)
 
     # ------------------------------------------------------------------
+    # Fluent builders — chainable, coerce "40 m" / "ean50" style arguments
+    # ------------------------------------------------------------------
+    # Each method starts from the current position (end pressure of the last
+    # segment, or the surface for an empty profile) and appends via
+    # add_segment(), so the active builder policy applies as usual.
+    #
+    #     profile = (
+    #         DiveProfile()
+    #         .descend_to("40 m")
+    #         .stay(20)
+    #         .ascend_to("21 m")
+    #         .switch_gas("ean50")
+    #         .surface()
+    #     )
+
+    def descend_to(
+        self,
+        depth: Pressure | str | float,
+        *,
+        rate: Optional[float] = None,
+        gas: Gas | str | None = None,
+    ) -> DiveProfile:
+        """Append a descent from the current position to `depth`.
+
+        Args:
+            depth: Target as a Pressure, a parseable string ("40 m", "5 bar"),
+                or a bare number in metres.
+            rate: Descent rate in m/min. Defaults to the configured
+                planning.descent_rate.
+            gas: Gas for the descent (Gas or name like "ean32"). Defaults to
+                the current gas (air on an empty profile).
+
+        Raises:
+            ValueError: If `depth` is not below the current position.
+        """
+        target = _as_pressure(depth)
+        start = self._get_last_pressure()
+        if target <= start:
+            raise ValueError(
+                f"descend_to target {target.depth_m:.1f} m is not below the "
+                f"current position {start.depth_m:.1f} m — use ascend_to()."
+            )
+        rate = rate if rate is not None else DiveConfig.current().planning.descent_rate
+        gas_mix = _as_gas(gas) if gas is not None else self._get_last_gas()
+        duration = abs(target.depth_m - start.depth_m) / rate
+        return self.add_segment(DiveSegment(start, target, duration, gas_mix))
+
+    def ascend_to(
+        self,
+        depth: Pressure | str | float,
+        *,
+        rate: Optional[float] = None,
+        gas: Gas | str | None = None,
+        kind: SegmentKind.Ascent = SegmentKind.ASCENT,
+    ) -> DiveProfile:
+        """Append an ascent from the current position to `depth`.
+
+        Args:
+            depth: Target as a Pressure, a parseable string ("21 m", "2 bar"),
+                or a bare number in metres.
+            rate: Ascent rate in m/min. Defaults to the configured
+                planning.ascent_rate.
+            gas: Gas for the ascent (Gas or name). Defaults to the current gas.
+            kind: Ascent kind. Defaults to SegmentKind.ASCENT (forced ascent).
+
+        Raises:
+            ValueError: If `depth` is not above the current position.
+        """
+        target = _as_pressure(depth)
+        start = self._get_last_pressure()
+        if target >= start:
+            raise ValueError(
+                f"ascend_to target {target.depth_m:.1f} m is not above the "
+                f"current position {start.depth_m:.1f} m — use descend_to()."
+            )
+        rate = rate if rate is not None else DiveConfig.current().planning.ascent_rate
+        gas_mix = _as_gas(gas) if gas is not None else self._get_last_gas()
+        duration = abs(target.depth_m - start.depth_m) / rate
+        return self.add_segment(
+            DiveSegment(start, target, duration, gas_mix, ascent_kind=kind)
+        )
+
+    def stay(
+        self,
+        duration: timedelta | float,
+        *,
+        gas: Gas | str | None = None,
+        kind: SegmentKind.Constant = SegmentKind.CONSTANT,
+    ) -> DiveProfile:
+        """Append a constant-depth segment at the current position.
+
+        Args:
+            duration: Time to stay — minutes as a number, or a timedelta.
+            gas: Gas for the segment (Gas or name). Defaults to the current gas.
+            kind: Constant kind, e.g. SegmentKind.Constant.STOP for a deco
+                stop. Defaults to SegmentKind.CONSTANT (bottom time).
+        """
+        here = self._get_last_pressure()
+        gas_mix = _as_gas(gas) if gas is not None else self._get_last_gas()
+        return self.add_segment(
+            DiveSegment(here, here, duration, gas_mix, constant_kind=kind)
+        )
+
+    def switch_gas(self, gas: Gas | str) -> DiveProfile:
+        """Append a gas switch at the current position.
+
+        The switch takes the configured gas.gas_switch_minutes (zero = instant
+        switch). Switching to the gas already in use is a no-op.
+
+        Args:
+            gas: The new gas (Gas or name like "ean50").
+        """
+        new_gas = _as_gas(gas)
+        if new_gas == self._get_last_gas():
+            return self
+        here = self._get_last_pressure()
+        return self.add_segment(
+            DiveSegment(
+                here,
+                here,
+                DiveConfig.current().gas.gas_switch_minutes,
+                new_gas,
+                constant_kind=SegmentKind.Constant.GAS_SWITCH,
+            )
+        )
+
+    def surface(self) -> DiveProfile:
+        """Append an ascent from the current position to the surface at the
+        configured ascent rate (alias for add_end_surface_segment).
+
+        Raises:
+            ProfileEmptyError: If the profile has no segments.
+        """
+        return self.add_end_surface_segment()
+
+    # ------------------------------------------------------------------
     # Validation
     # ------------------------------------------------------------------
 
@@ -587,9 +814,7 @@ class DiveProfile:
         if isinstance(error, ProfileStartEndError):
             self.add_surface_segments()
         elif isinstance(error, ProfileDepthContinuityError):
-            transition = self.make_transition_segment(
-                error.segment_a, error.segment_b
-            )
+            transition = self.make_transition_segment(error.segment_a, error.segment_b)
             self._segments.insert(error.segment_index + 1, transition)
         elif isinstance(error, ProfileGasContinuityError):
             switch = self.make_gas_switch_segment(error.segment_a, error.segment_b)
@@ -811,3 +1036,55 @@ class DiveProfile:
         if not self._segments:
             raise ProfileEmptyError()
         return self.add_end_surface_segment().add_start_surface_segment()
+
+    # ------------------------------------------------------------------
+    # Serialization
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict (builder policy + segments)."""
+        return {
+            "builder_policy": self._builder_policy.name,
+            "segments": [segment.to_dict() for segment in self._segments],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> DiveProfile:
+        """Reconstruct a DiveProfile from :meth:`to_dict` output.
+
+        Segments are loaded exactly as saved, *without* re-validating seams —
+        a stored in-progress profile must round-trip even if it is not (yet)
+        continuous. Call .validate_profile() after loading if you need the
+        guarantees of the RAISE policy.
+
+        Raises:
+            KeyError: If the "segments" field is missing, or an unknown
+                builder policy name is given.
+            ValueError: If a segment entry is malformed.
+        """
+        profile = cls.__new__(cls)
+        profile._builder_policy = ProfileBuilderPolicy[
+            data.get("builder_policy", ProfileBuilderPolicy.RAISE_BAD_PROFILE.name)
+        ]
+        profile._segments = [DiveSegment.from_dict(entry) for entry in data["segments"]]
+        return profile
+
+    def to_json(self, path: Optional[str] = None, indent: int = 2) -> str:
+        """Serialize to a JSON string, optionally writing to a file."""
+        data = json.dumps(self.to_dict(), indent=indent)
+        if path:
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(data)
+        return data
+
+    @classmethod
+    def from_json(
+        cls, data: Optional[str] = None, path: Optional[str] = None
+    ) -> DiveProfile:
+        """Deserialize from a JSON string or file path (see :meth:`from_dict`)."""
+        if path:
+            with open(path, encoding="utf-8") as f:
+                data = f.read()
+        if data is None:
+            raise ValueError("Provide either 'data' or 'path'")
+        return cls.from_dict(json.loads(data))

--- a/src/diveplan/models/base.py
+++ b/src/diveplan/models/base.py
@@ -1,47 +1,78 @@
+"""Decompression model base classes.
+
+Each deco model defines its own :class:`DecoState` subclass — the typed,
+copyable snapshot of everything the model knows at an instant (tissue
+tensions, ceiling, …). Models are generic over their state type, so
+``ZHL16C.integrate_segment(...)`` returns a ``ZHL16State``, not a bare dict.
+State snapshots are what the result/report layer stores at checkpoints and
+what counterfactual queries (TTS at time t) resume from.
+"""
+
 from abc import ABC, abstractmethod
 from datetime import timedelta
-from typing import Any
+from typing import ClassVar
 
+from diveplan.core.dive_segment import DiveSegment
 from diveplan.core.gas import Gas
+from diveplan.core.pressure import Pressure
 
-from ..core.dive_segment import DiveSegment
-from ..core.pressure import Pressure
-
-__all__ = ["BaseDecoModel"]
+__all__ = ["BaseDecoModel", "DecoState"]
 
 
-class BaseDecoModel(ABC):
-    """Base class for all decompression models."""
+class DecoState:
+    """Base class for model-specific decompression state snapshots.
 
-    __slots__ = ["sample_rate_seconds"]
+    Subclasses should be immutable value objects (frozen dataclass or
+    ``__slots__`` with guards) so they can be checkpointed, compared, and
+    resumed from without defensive copying.
+    """
 
-    NAME: str
+    __slots__ = ()
+
+
+class BaseDecoModel[StateT: DecoState](ABC):
+    """Base class for all decompression models.
+
+    Generic over the model's :class:`DecoState` subclass: each model type
+    processes and returns its own state type.
+    """
+
+    __slots__ = ("sample_rate_seconds",)
+
+    NAME: ClassVar[str]
 
     @abstractmethod
-    def __init__(self, *args, **kwargs):
+    def __init__(self) -> None:
         """Initialize the decompression model."""
         self.sample_rate_seconds = 1
-        pass
 
-    def integrate_segment(self, segment: DiveSegment) -> dict[str, Any]:
-        """Integrate a dive segment into the model."""
+    def integrate_segment(self, segment: DiveSegment) -> StateT:
+        """Integrate a dive segment into the model and return the state after it.
 
-        sample_time = timedelta(seconds=self.sample_rate_seconds)
+        Numerical scheme: rectangle rule — each sample step is integrated at
+        the pressure of its end point over the actual elapsed dt (the final
+        step may be shorter than the sample rate). Models with an analytic
+        solution for linear pressure change (Schreiner) should override this.
+        """
+        interval = timedelta(seconds=self.sample_rate_seconds)
 
-        for duration, pressure in segment.iter_pressures(sample_time):
-            self._integrate_model(pressure, segment.gas, duration)
+        previous = timedelta(0)
+        for elapsed, pressure in segment.iter_pressures(interval):
+            dt = elapsed - previous
+            if dt > timedelta(0):
+                self._integrate_model(pressure, segment.gas, dt)
+            previous = elapsed
 
         return self._get_deco_state()
 
     @abstractmethod
-    def _integrate_model(self, pressure: Pressure, gas: Gas, duration: timedelta):
-        pass
+    def _integrate_model(self, pressure: Pressure, gas: Gas, dt: timedelta) -> None:
+        """Advance the model by dt at the given ambient pressure and gas."""
 
     @abstractmethod
-    def _get_deco_state(self) -> dict[str, Any]:
-        pass
+    def _get_deco_state(self) -> StateT:
+        """Snapshot the current model state."""
 
     @abstractmethod
     def get_ceiling(self) -> Pressure:
         """Return the current ceiling depth."""
-        pass

--- a/src/diveplan/registry.py
+++ b/src/diveplan/registry.py
@@ -1,6 +1,6 @@
 from functools import cached_property
 from importlib.metadata import entry_points
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .models.base import BaseDecoModel
@@ -28,14 +28,14 @@ class PluginRegistry:
     def __init__(self) -> None:
         # Manual overrides live here — separate from the cached discovery.
         # Checked first so local overrides win over installed packages.
-        self._overrides: dict[str, type[BaseDecoModel]] = {}
+        self._overrides: dict[str, type[BaseDecoModel[Any]]] = {}
 
     @cached_property
-    def _discovered(self) -> dict[str, type[BaseDecoModel]]:
+    def _discovered(self) -> dict[str, type[BaseDecoModel[Any]]]:
         """Discovered once from entry points, then frozen."""
         from .models.base import BaseDecoModel
 
-        found: dict[str, type[BaseDecoModel]] = {}
+        found: dict[str, type[BaseDecoModel[Any]]] = {}
         for ep in entry_points(group=_ENTRY_POINT_GROUP):
             cls = ep.load()
             if not (isinstance(cls, type) and issubclass(cls, BaseDecoModel)):
@@ -47,24 +47,24 @@ class PluginRegistry:
         return found
 
     @property
-    def _all(self) -> dict[str, type[BaseDecoModel]]:
+    def _all(self) -> dict[str, type[BaseDecoModel[Any]]]:
         """Overrides shadow discovered plugins of the same name."""
         return {**self._discovered, **self._overrides}
 
     # ── Public API ──────────────────────────────────────────────────────────
 
-    def model(self, name: str) -> type[BaseDecoModel]:
+    def model(self, name: str) -> type[BaseDecoModel[Any]]:
         """Return the plugin class for *name*, or raise PluginNotFoundError."""
         plugins = self._all
         if name not in plugins:
             raise PluginNotFoundError(name, available=list(plugins))
         return plugins[name]
 
-    def all_models(self) -> dict[str, type[BaseDecoModel]]:
+    def all_models(self) -> dict[str, type[BaseDecoModel[Any]]]:
         """All registered plugins, keyed by name."""
         return dict(self._all)
 
-    def register_model(self, name: str, cls: type[BaseDecoModel]) -> None:
+    def register_model(self, name: str, cls: type[BaseDecoModel[Any]]) -> None:
         """
         Manually register a plugin class — escape hatch for tests,
         notebooks, or plugins that ship inside the core package.

--- a/tests/test_dive_profile.py
+++ b/tests/test_dive_profile.py
@@ -7,6 +7,8 @@ and ascent/descent rates are deterministic. This exercises the real continuity
 logic instead of asserting against hand-wired mock return values.
 """
 
+from datetime import timedelta
+
 import pytest
 
 from diveplan.core.dive_segment import DiveSegment, SegmentKind
@@ -204,7 +206,8 @@ class TestDiveProfileBuilder:
         profile = DiveProfile(ALLOW)
         seg = descent(P1, P2)
         profile.add_segment(seg)
-        assert profile._get_last_pressure() == seg.start_pressure
+        # Current position is where the last segment *ends*.
+        assert profile._get_last_pressure() == seg.end_pressure
         assert profile._get_last_gas() == seg.gas
 
 
@@ -266,8 +269,7 @@ class TestDiveProfileValidation:
             [descent(SURF, P2, gas=AIR), switch, ascent(P2, SURF, gas=EAN32)]
         )
         assert not any(
-            isinstance(e, ProfileGasContinuityError)
-            for e in profile.validate_profile()
+            isinstance(e, ProfileGasContinuityError) for e in profile.validate_profile()
         )
 
     def test_validate_simplicity_error(self):
@@ -446,3 +448,210 @@ class TestDiveProfileFixes:
         pressure_gap = descent(P3, P4, gas=EAN32)
         with pytest.raises(ValueError, match="pressure discontinuity"):
             DiveProfile.make_gas_switch_segment(a, pressure_gap)
+
+
+# ------------------------------------------------------------------
+# Timeline
+# ------------------------------------------------------------------
+
+
+class TestDiveProfileTimeline:
+    def test_runtime_empty(self):
+        assert DiveProfile(ALLOW).runtime == timedelta(0)
+
+    def test_runtime(self):
+        profile = valid_profile()  # 2 min descent + 5 min ascent
+        assert profile.runtime == timedelta(minutes=7)
+
+    def test_start_time_of_segment(self):
+        profile = valid_profile()
+        assert profile.start_time_of_segment(0) == timedelta(0)
+        assert profile.start_time_of_segment(1) == timedelta(minutes=2)
+        assert profile.start_time_of_segment(-1) == timedelta(minutes=2)
+        with pytest.raises(IndexError):
+            profile.start_time_of_segment(2)
+
+    def test_segment_index_at(self):
+        profile = valid_profile()
+        assert profile.segment_index_at(0) == 0
+        assert profile.segment_index_at(1.9) == 0
+        assert profile.segment_index_at(2) == 1  # boundary belongs to the later segment
+        assert profile.segment_index_at(timedelta(minutes=7)) == 1  # t == runtime
+
+    def test_segment_index_at_out_of_range(self):
+        profile = valid_profile()
+        with pytest.raises(ValueError, match="negative"):
+            profile.segment_index_at(-1)
+        with pytest.raises(ValueError, match="beyond"):
+            profile.segment_index_at(7.5)
+
+    def test_segment_index_at_empty(self):
+        with pytest.raises(ProfileEmptyError):
+            DiveProfile(ALLOW).segment_index_at(0)
+
+    def test_segment_at_and_gas_at(self):
+        profile = DiveProfile(ALLOW)
+        profile.add_segments(
+            [
+                descent(SURF, P4, minutes=2, gas=AIR),
+                DiveSegment(P4, P4, 20, AIR),
+                DiveSegment(
+                    P4, P4, 1, EAN32, constant_kind=SegmentKind.Constant.GAS_SWITCH
+                ),
+                ascent(P4, SURF, minutes=5, gas=EAN32),
+            ]
+        )
+        assert profile.gas_at(1) == AIR
+        assert profile.gas_at(10) == AIR
+        assert profile.gas_at(22.5) == EAN32  # inside the switch
+        assert profile.gas_at(25) == EAN32
+        assert profile.segment_at(10).kind is SegmentKind.Constant.BOTTOM
+
+    def test_pressure_at_interpolates(self):
+        profile = valid_profile()  # SURF -> P4 over 2 min
+        assert profile.pressure_at(0) == SURF
+        mid = profile.pressure_at(1)
+        assert mid == Pressure(round((SURF.mbar + P4.mbar) / 2))
+        assert profile.pressure_at(profile.runtime) == SURF
+
+    def test_pressure_at_zero_duration_final_segment(self):
+        from diveplan.core.config import DiveConfig
+
+        DiveConfig.current().gas.gas_switch_minutes = 0
+        profile = DiveProfile(ALLOW)
+        profile.add_segment(descent(SURF, P4, minutes=2))
+        profile.switch_gas(EAN32)
+        assert profile.pressure_at(2) == P4
+        assert profile.gas_at(2) == EAN32
+
+
+# ------------------------------------------------------------------
+# Fluent builders
+# ------------------------------------------------------------------
+
+
+class TestDiveProfileFluentBuilders:
+    def test_fluent_chain(self):
+        profile = (
+            DiveProfile()
+            .descend_to("40 m")
+            .stay(20)
+            .ascend_to("21 m")
+            .switch_gas("ean50")
+            .surface()
+        )
+        assert profile.is_valid
+        assert profile.validate_profile(skip_start_end_segments=False) == ()
+        kinds = [s.kind for s in profile.segments]
+        assert kinds[0] is SegmentKind.DESCENT
+        assert kinds[1] is SegmentKind.Constant.BOTTOM
+        assert SegmentKind.Constant.GAS_SWITCH in kinds
+        assert profile.segments[-1].end_pressure == Pressure.surface()
+        assert profile.segments[-1].gas == Gas.nitrox(0.50)
+
+    def test_descend_to_uses_config_rate(self):
+        from diveplan.core.config import DiveConfig
+
+        profile = DiveProfile().descend_to(40)
+        rate = DiveConfig.current().planning.descent_rate
+        expected = timedelta(minutes=40 / rate)
+        assert abs(profile.segments[0].duration - expected) < timedelta(seconds=1)
+
+    def test_descend_to_accepts_pressure_string_and_number(self):
+        for depth in ("40 m", 40, Pressure.from_depth_m(40)):
+            profile = DiveProfile().descend_to(depth)
+            assert profile.segments[0].end_pressure == Pressure.from_depth_m(40)
+
+    def test_descend_to_wrong_direction(self):
+        profile = DiveProfile().descend_to("40 m")
+        with pytest.raises(ValueError, match="use ascend_to"):
+            profile.descend_to("30 m")
+
+    def test_ascend_to_wrong_direction(self):
+        profile = DiveProfile().descend_to("30 m")
+        with pytest.raises(ValueError, match="use descend_to"):
+            profile.ascend_to("40 m")
+
+    def test_stay_defaults_to_last_gas_and_depth(self):
+        profile = DiveProfile().descend_to("30 m", gas="ean32").stay(15)
+        seg = profile.get_last_segment()
+        assert seg.start_pressure == seg.end_pressure == Pressure.from_depth_m(30)
+        assert seg.gas == EAN32
+        assert seg.duration == timedelta(minutes=15)
+
+    def test_stay_stop_kind(self):
+        profile = (
+            DiveProfile().descend_to("6 m").stay(3, kind=SegmentKind.Constant.STOP)
+        )
+        assert profile.get_last_segment().kind is SegmentKind.Constant.STOP
+
+    def test_switch_gas_same_gas_is_noop(self):
+        profile = DiveProfile().descend_to("30 m")  # air
+        count = profile.segment_count
+        profile.switch_gas("air")
+        assert profile.segment_count == count
+
+    def test_switch_gas_duration_from_config(self):
+        from diveplan.core.config import DiveConfig
+
+        DiveConfig.current().gas.gas_switch_minutes = 2.0
+        profile = DiveProfile().descend_to("30 m").switch_gas(EAN32)
+        seg = profile.get_last_segment()
+        assert seg.kind is SegmentKind.Constant.GAS_SWITCH
+        assert seg.duration == timedelta(minutes=2)
+        assert seg.gas == EAN32
+
+    def test_surface_on_empty_raises(self):
+        with pytest.raises(ProfileEmptyError):
+            DiveProfile().surface()
+
+    def test_fluent_respects_raise_policy(self):
+        # descend_to on RAISE policy starts from the current position, so the
+        # chain is always seam-continuous — no policy violation possible.
+        profile = DiveProfile().descend_to("40 m").stay(5).surface()
+        assert profile.builder_policy is RAISE
+        assert profile.is_valid
+
+
+# ------------------------------------------------------------------
+# Serialization
+# ------------------------------------------------------------------
+
+
+class TestDiveProfileSerialization:
+    def test_dict_round_trip(self):
+        profile = (
+            DiveProfile()
+            .descend_to("40 m")
+            .stay(20)
+            .ascend_to("21 m")
+            .switch_gas("ean50")
+            .surface()
+        )
+        restored = DiveProfile.from_dict(profile.to_dict())
+        assert restored.segments == profile.segments
+        assert restored.builder_policy is profile.builder_policy
+
+    def test_json_round_trip(self, tmp_path):
+        profile = DiveProfile(ALLOW).descend_to("30 m").stay(10)
+        path = tmp_path / "profile.json"
+        profile.to_json(path=str(path))
+        restored = DiveProfile.from_json(path=str(path))
+        assert restored.segments == profile.segments
+        assert restored.builder_policy is ALLOW
+
+    def test_from_dict_does_not_revalidate(self):
+        # A discontinuous (in-progress) profile must round-trip even though
+        # it would be rejected by the RAISE policy at build time.
+        profile = DiveProfile(ALLOW)
+        profile.add_segments([descent(SURF, P2), descent(P3, P4)])
+        data = profile.to_dict()
+        data["builder_policy"] = "RAISE_BAD_PROFILE"
+        restored = DiveProfile.from_dict(data)
+        assert restored.segment_count == 2
+        assert restored.builder_policy is RAISE
+        assert len(restored.validate_profile()) == 1
+
+    def test_from_json_requires_data_or_path(self):
+        with pytest.raises(ValueError, match="data.*or.*path"):
+            DiveProfile.from_json()

--- a/tests/test_dive_segment.py
+++ b/tests/test_dive_segment.py
@@ -383,3 +383,83 @@ class TestDiveSegmentMagicMethods:
         seg = DiveSegment(p1, p2, 3, air)
         s = str(seg)
         assert "DESCENT segment from 0.0m to 30.0m" in s
+
+
+# ------------------------------------------------------------------
+# Immutability
+# ------------------------------------------------------------------
+
+
+class TestDiveSegmentImmutability:
+    def test_setattr_raises(self, p1000, p3000, air, ean32):
+        seg = DiveSegment(p1000, p3000, 2, air)
+        with pytest.raises(AttributeError, match="immutable"):
+            seg.gas = ean32
+        with pytest.raises(AttributeError, match="immutable"):
+            seg.duration = td(minutes=99)
+
+    def test_delattr_raises(self, p1000, p3000, air):
+        seg = DiveSegment(p1000, p3000, 2, air)
+        with pytest.raises(AttributeError, match="immutable"):
+            del seg.gas
+
+    def test_hash_stable(self, p1000, p3000, air):
+        seg = DiveSegment(p1000, p3000, 2, air)
+        assert hash(seg) == hash(DiveSegment(p1000, p3000, 2, air))
+
+
+# ------------------------------------------------------------------
+# Serialization
+# ------------------------------------------------------------------
+
+
+class TestDiveSegmentSerialization:
+    def test_to_dict(self, p1000, p3000, air):
+        seg = DiveSegment(p1000, p3000, 2, air)
+        d = seg.to_dict()
+        assert d["start_pressure_mbar"] == 1000
+        assert d["end_pressure_mbar"] == 3000
+        assert d["duration_s"] == 120.0
+        assert d["gas"] == {"fo2": 0.21, "fhe": 0.0}
+        assert d["kind"] == "DESCENT"
+
+    @pytest.mark.parametrize(
+        "make",
+        [
+            lambda p1000, p3000, air, ean32: DiveSegment(p1000, p3000, 2, air),
+            lambda p1000, p3000, air, ean32: DiveSegment(
+                p3000, p1000, 5, air, ascent_kind=SegmentKind.Ascent.DECO_ASCENT
+            ),
+            lambda p1000, p3000, air, ean32: DiveSegment(
+                p3000, p3000, 3, air, constant_kind=SegmentKind.Constant.STOP
+            ),
+            lambda p1000, p3000, air, ean32: DiveSegment(
+                p3000, p3000, 0, ean32, constant_kind=SegmentKind.Constant.GAS_SWITCH
+            ),
+        ],
+        ids=["descent", "deco_ascent", "stop", "instant_gas_switch"],
+    )
+    def test_dict_round_trip(self, make, p1000, p3000, air, ean32):
+        seg = make(p1000, p3000, air, ean32)
+        assert DiveSegment.from_dict(seg.to_dict()) == seg
+
+    def test_json_round_trip(self, p1000, p3000, ean32):
+        seg = DiveSegment(p1000, p3000, 2, ean32)
+        assert DiveSegment.from_json(seg.to_json()) == seg
+
+    def test_from_dict_kind_geometry_mismatch(self, p1000, p3000, air):
+        d = DiveSegment(p1000, p3000, 2, air).to_dict()
+        d["kind"] = "DECO_ASCENT"  # but pressures describe a descent
+        with pytest.raises(ValueError, match="contradicts pressure geometry"):
+            DiveSegment.from_dict(d)
+
+    def test_from_dict_unknown_kind(self, p1000, p3000, air):
+        d = DiveSegment(p1000, p3000, 2, air).to_dict()
+        d["kind"] = "SIDEWAYS"
+        with pytest.raises(ValueError, match="Unknown segment kind"):
+            DiveSegment.from_dict(d)
+
+    def test_segment_kind_from_name(self):
+        assert SegmentKind.from_name("descent") is SegmentKind.Descent.DESCENT
+        assert SegmentKind.from_name("STOP") is SegmentKind.Constant.STOP
+        assert SegmentKind.from_name("GAS_SWITCH") is SegmentKind.Constant.GAS_SWITCH


### PR DESCRIPTION
## Summary

Follow-up to the core-foundation review. Five logical commits:

- **DiveSegment is now actually immutable** (`__setattr__`/`__delattr__` guards) — the docstring, `__hash__`, and `DiveProfile.copy()`'s shallow-copy assumption all depended on this; plus dict/JSON serialization with kind-vs-geometry validation on load, and `SegmentKind.from_name`.
- **DiveProfile timeline**: `runtime`, `segment_at(t)`, `pressure_at(t)`, `gas_at(t)` — address the dive by runtime, not segment index. Seam convention: `[start, end)`, final segment owns `t == runtime`.
- **Fluent builders**: `.descend_to("40 m").stay(20).ascend_to("21 m").switch_gas("ean50").surface()` with coercion shared from `utils.conversions`. Fixes a latent bug: `_get_last_pressure` returned the last segment's *start* pressure instead of its end.
- **Typed model layer**: `DecoState` base + `BaseDecoModel[StateT: DecoState]` (PEP 695) replacing `dict[str, Any]`; fixes `integrate_segment` passing cumulative elapsed time as the integration step (would have massively over-integrated tissues).
- **Entry-point fix**: registry group (`diveplan.deco_models`) and pyproject disagreed, so the built-in model could never be discovered; dangling entries (zhl16c, formatters) are gated until their modules land.
- **Pressure.to_str** now takes a `PressureUnit` Literal.
- CLAUDE.md + auto-generated codebase index (`.claude/`).

## Testing

- 325 tests pass (36 new: immutability, serialization round-trips, timeline semantics incl. zero-duration gas-switch edge cases, fluent chains, policy interaction)
- `ruff check` clean; `mypy src` strict — no new errors (3 pre-existing in `models/buhlmann/common.py`, addressed in the next PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)