### PR TITLE
Bühlmann rewrite + ZHL-16C implementation

### DIFF
--- a/.claude/codebase-index.md
+++ b/.claude/codebase-index.md
@@ -251,8 +251,8 @@ Decompression model base classes.
   attrs: `NAME: ClassVar[str]`
 
 ## `src/diveplan/models/buhlmann/__init__.py`
-Bühlmann decompression models and shared helpers.
-`__all__ = ['ZHL16C', 'ZHL16State', 'Compartment', 'Gradient']`
+Bühlmann-family decompression models.
+`__all__ = ['BuhlmannModel', 'BuhlmannState', 'ZHL16C', 'Compartment', 'Gradient']`
 
 ## `src/diveplan/models/buhlmann/common.py`
 Shared Bühlmann machinery: gradient factors and Haldane tissue compartments.
@@ -277,31 +277,32 @@ Shared Bühlmann machinery: gradient factors and Haldane tissue compartments.
   attrs: `ht_n2: float; ht_he: float; a_n2: float; a_he: float; b_n2: float; b_he: float`
   dunders: `__eq__, __hash__, __repr__, __str__`
 
-## `src/diveplan/models/buhlmann/zhl16.py`
-Bühlmann ZHL-16C decompression model.
-`__all__ = ['ZHL16C', 'ZHL16State']`
-- const `N2_HALF_TIMES = (5.0, 8.0, 12.5, 18.5, 27.0, 38.3, 54.3, 77.0, 109.0, 146.0, 187.0, 239.0, 305.0, 390.0, 498.0, 635.0)`
-- const `N2_A = (1.1696, 1.0, 0.8618, 0.7562, 0.62, 0.5043, 0.441, 0.4, 0.375, 0.35, 0.3295, 0.3065, 0.2835, 0.261, 0.248, 0.2327)`
-- const `N2_B = (0.5578, 0.6514, 0.7222, 0.7825, 0.8126, 0.8434, 0.8693, 0.891, 0.9092, 0.9222, 0.9319, 0.9403, 0.9477, 0.9544, 0.9602, 0.9653)`
-- const `HE_HALF_TIMES = (1.88, 3.02, 4.72, 6.99, 10.21, 14.48, 20.53, 29.11, 41.2, 55.19, 70.69, 90.34, 115.29, 147.42, 188.24, 240.03)`
-- const `HE_A = (1.6189, 1.383, 1.1919, 1.0458, 0.922, 0.8205, 0.7305, 0.6502, 0.595, 0.5545, 0.5333, 0.5189, 0.5181, 0.5176, 0.5172, 0.5119)`
-- const `HE_B = (0.477, 0.5747, 0.6527, 0.7223, 0.7582, 0.7957, 0.8279, 0.8553, 0.8757, 0.8903, 0.8997, 0.9073, 0.9122, 0.9171, 0.9217, 0.9267)`
-- const `COMPARTMENT_COUNT = 16`
-### class `ZHL16State` (DecoState) — Frozen snapshot of the 16 (ppn2, pphe) tissue tensions in float mbar.
+## `src/diveplan/models/buhlmann/model.py`
+Generic Bühlmann decompression engine.
+`__all__ = ['BuhlmannModel', 'BuhlmannState']`
+### class `BuhlmannState` (DecoState) — Frozen snapshot of (ppn2, pphe) tissue tensions in float mbar.
   `__slots__ = ('tissues',)`
   - `__init__(self, tissues: tuple[tuple[float, float], ...])`
   attrs: `tissues: tuple[tuple[float, float], ...]`
   dunders: `__delattr__, __eq__, __hash__, __repr__, __setattr__`
-### class `ZHL16C` (BaseDecoModel[ZHL16State]) — Bühlmann ZHL-16C with Baker gradient factors.
+### class `BuhlmannModel` (BaseDecoModel[BuhlmannState]) — Bühlmann algorithm over a subclass-supplied coefficient table.
   `__slots__ = ('gradient', '_compartments')`
   - `__init__(self, gradient: Gradient | None = None)`
+  - @property `compartment_count(self) -> int`  — Number of tissue compartments in this model's table.
   - `_integrate_model(self, pressure: Pressure, gas: Gas, dt: timedelta) -> None`
-  - `_get_deco_state(self) -> ZHL16State`
+  - `_get_deco_state(self) -> BuhlmannState`
   - `get_ceiling(self, gradient_factor: float | None = None) -> Pressure`  — Minimum tolerated ambient pressure across all compartments.
-  - `set_state(self, state: ZHL16State) -> None`  — Restore tissue tensions from a snapshot (exact, lossless).
-  - `copy(self) -> 'ZHL16C'`  — Independent clone with the same gradient and tissue tensions —
-  attrs: `NAME = 'zhl16c'; gradient: Gradient`
-  dunders: `__repr__`
+  - `set_state(self, state: BuhlmannState) -> None`  — Restore tissue tensions from a snapshot (exact, lossless).
+  - `copy(self) -> Self`  — Independent clone with the same gradient and tissue tensions —
+  attrs: `N2_HALF_TIMES: ClassVar[tuple[float, ...]]; N2_A: ClassVar[tuple[float, ...]]; N2_B: ClassVar[tuple[float, ...]]; HE_HALF_TIMES: ClassVar[tuple[float, ...]]; HE_A: ClassVar[tuple[float, ...]]; HE_B: ClassVar[tuple[float, ...]]; gradient: Gradient`
+  dunders: `__init_subclass__, __repr__`
+
+## `src/diveplan/models/buhlmann/zhl16.py`
+Bühlmann ZHL-16 variants — coefficient tables over the shared engine.
+`__all__ = ['ZHL16C', 'BuhlmannState']`
+### class `ZHL16C` (BuhlmannModel) — Bühlmann ZHL-16C, 16 compartments (1b first-compartment variant).
+  `__slots__ = ()`
+  attrs: `NAME = 'zhl16c'; N2_HALF_TIMES = (5.0, 8.0, 12.5, 18.5, 27.0, 38.3, 54.3, 77.0, 109.0, 146.0, 187.0, 239.0, 305.0, 390.0, 498.0, 635.0); N2_A = (1.1696, 1.0, 0.8618, 0.7562, 0.62, 0.5043, 0.441, 0.4, 0.375, 0.35, 0.3295, 0.3065, 0.2835, 0.261, 0.248, 0.2327); N2_B = (0.5578, 0.6514, 0.7222, 0.7825, 0.8126, 0.8434, 0.8693, 0.891, 0.9092, 0.9222, 0.9319, 0.9403, 0.9477, 0.9544, 0.9602, 0.9653); HE_HALF_TIMES = (1.88, 3.02, 4.72, 6.99, 10.21, 14.48, 20.53, 29.11, 41.2, 55.19, 70.69, 90.34, 115.29, 147.42, 188.24, 240.03); HE_A = (1.6189, 1.383, 1.1919, 1.0458, 0.922, 0.8205, 0.7305, 0.6502, 0.595, 0.5545, 0.5333, 0.5189, 0.5181, 0.5176, 0.5172, 0.5119); HE_B = (0.477, 0.5747, 0.6527, 0.7223, 0.7582, 0.7957, 0.8279, 0.8553, 0.8757, 0.8903, 0.8997, 0.9073, 0.9122, 0.9171, 0.9217, 0.9267)`
 
 ## `src/diveplan/planning/__init__.py`
 (empty stub)
@@ -339,7 +340,7 @@ Bühlmann ZHL-16C decompression model.
 
 # Tests (tests/)
 - `conftest.py` (0 tests)
-- `test_buhlmann.py` (38 tests) — TestGradient, TestCompartmentState, TestCompartmentIntegration, TestCompartmentToleratedPressure, TestZHL16CTables, TestZHL16CModel, TestZHL16CRegistry
+- `test_buhlmann.py` (44 tests) — TestGradient, TestCompartmentState, TestCompartmentIntegration, TestCompartmentToleratedPressure, TestZHL16CTables, TestZHL16CModel, MiniBuhlmann, TestBuhlmannFamily, TestZHL16CRegistry
 - `test_config.py` (45 tests) — TestSubConfigBase, TestPhysicsConfig, TestGasConfig, TestDivePlanningConfig, TestDiveConfigStructure, TestGlobalDefault, TestContextManager, TestDefaultConfigLoading, TestSerialization
 - `test_dive_profile.py` (74 tests) — TestDiveProfileBuilder, TestDiveProfileValidation, TestDiveProfileFixes, TestDiveProfileTimeline, TestDiveProfileFluentBuilders, TestDiveProfileSerialization
 - `test_dive_segment.py` (59 tests) — TestDiveSegmentConstruction, TestDiveSegmentProperties, TestDiveSegmentInterpolation, TestDiveSegmentSplitting, TestDiveSegmentMerging, TestDiveSegmentContinuity, TestDiveSegmentIteration, TestDiveSegmentMagicMethods, TestDiveSegmentImmutability, TestDiveSegmentSerialization

--- a/.claude/codebase-index.md
+++ b/.claude/codebase-index.md
@@ -251,28 +251,57 @@ Decompression model base classes.
   attrs: `NAME: ClassVar[str]`
 
 ## `src/diveplan/models/buhlmann/__init__.py`
-(empty stub)
+Bühlmann decompression models and shared helpers.
+`__all__ = ['ZHL16C', 'ZHL16State', 'Compartment', 'Gradient']`
 
 ## `src/diveplan/models/buhlmann/common.py`
-`__all__ = ('Gradient', 'Compartment')`
-### class `Gradient` — Helper for computing gradients of dive segments.
+Shared Bühlmann machinery: gradient factors and Haldane tissue compartments.
+`__all__ = ('Gradient', 'Compartment', 'WATER_VAPOR_PRESSURE_MBAR')`
+- const `WATER_VAPOR_PRESSURE_MBAR = 62.7`
+### class `Gradient` — A gradient-factor pair (Baker GF low/high), as fractions.
   `__slots__ = ('gf_low', 'gf_high')`
   - `__init__(self, gf_low: float, gf_high: float)`
-  - `factor(self, depth_pressure: Pressure, max_depth_pressure: Pressure) -> float`  — Linearly interpolate the gradient for a given depth.
+  - `factor(self, pressure: Pressure, first_stop_pressure: Pressure) -> float`  — Gradient factor applicable at ``pressure``.
   attrs: `gf_low: float; gf_high: float`
   dunders: `__eq__, __hash__, __repr__, __str__`
-### class `Compartment` — Helper for tracking compartment constants and saturation.
-  `__slots__ = ('ppn2', 'pphe', 'ht_n2', 'ht_he', 'a_n2', 'a_he', 'b_n2', 'b_he', 'tolerated_pressure')`
+### class `Compartment` — One Haldane tissue compartment with Bühlmann a/b coefficients.
+  `__slots__ = ('ht_n2', 'ht_he', 'a_n2', 'a_he', 'b_n2', 'b_he', '_ppn2_mbar', '_pphe_mbar')`
   - `__init__(self, *, ht_n2: float, ht_he: float, a_n2: float, a_he: float, b_n2: float, b_he: float, ppn2: Optional[Pressure] = None, pphe: Optional[Pressure] = None)`
-  - `update_compartment(self, pressure: Pressure, gas: Gas, duration: timedelta, gradient_factor: float)`
-  - `_integrate_compartment(self, pressure: Pressure, gas: Gas, duration: timedelta)`
-  - `_update_compartment_max_tolerated_pressure(self, ambiant_pressure: Pressure, gradient_factor: float)`
-  - @staticmethod `_calc_inert_gas_pressure(ambiant_pressure: Pressure, inspired_gas_pressure: Pressure, time_minutes: float, half_time_minutes: float) -> Pressure`
-  - @staticmethod `_calcInertGasLimit(ppn2: Pressure, pphe: Pressure, a_n2: float, b_n2: float, a_he: float, b_he: float, ambiant_pressure: Pressure, gradient_factor: float) -> Pressure`
-  - `is_eq_pressures_only(self, other: Compartment) -> bool`
-  - `is_eq_with_pressures(self, other: Compartment) -> bool`
-  attrs: `ppn2: Pressure; pphe: Pressure; ht_n2: float; ht_he: float; a_n2: float; a_he: float; b_n2: float; b_he: float`
+  - @property `ppn2(self) -> Pressure`  — Current N2 tension (rounded to integer mbar for display/compare).
+  - @property `pphe(self) -> Pressure`  — Current He tension (rounded to integer mbar for display/compare).
+  - @property `tensions_mbar(self) -> tuple[float, float]`  — Exact (ppn2, pphe) tensions in float mbar — for state snapshots.
+  - `set_tensions_mbar(self, ppn2_mbar: float, pphe_mbar: float) -> None`  — Restore exact tensions from a state snapshot.
+  - `copy(self) -> 'Compartment'`  — Independent copy with the same constants and current tensions.
+  - `integrate(self, pressure: Pressure, gas: Gas, duration: timedelta) -> None`  — Haldane exponential update toward the alveolar inert pressures.
+  - `tolerated_ambient_pressure(self, gradient_factor: float = 1.0) -> Pressure`  — Minimum ambient pressure this compartment tolerates (Baker formula).
+  attrs: `ht_n2: float; ht_he: float; a_n2: float; a_he: float; b_n2: float; b_he: float`
   dunders: `__eq__, __hash__, __repr__, __str__`
+
+## `src/diveplan/models/buhlmann/zhl16.py`
+Bühlmann ZHL-16C decompression model.
+`__all__ = ['ZHL16C', 'ZHL16State']`
+- const `N2_HALF_TIMES = (5.0, 8.0, 12.5, 18.5, 27.0, 38.3, 54.3, 77.0, 109.0, 146.0, 187.0, 239.0, 305.0, 390.0, 498.0, 635.0)`
+- const `N2_A = (1.1696, 1.0, 0.8618, 0.7562, 0.62, 0.5043, 0.441, 0.4, 0.375, 0.35, 0.3295, 0.3065, 0.2835, 0.261, 0.248, 0.2327)`
+- const `N2_B = (0.5578, 0.6514, 0.7222, 0.7825, 0.8126, 0.8434, 0.8693, 0.891, 0.9092, 0.9222, 0.9319, 0.9403, 0.9477, 0.9544, 0.9602, 0.9653)`
+- const `HE_HALF_TIMES = (1.88, 3.02, 4.72, 6.99, 10.21, 14.48, 20.53, 29.11, 41.2, 55.19, 70.69, 90.34, 115.29, 147.42, 188.24, 240.03)`
+- const `HE_A = (1.6189, 1.383, 1.1919, 1.0458, 0.922, 0.8205, 0.7305, 0.6502, 0.595, 0.5545, 0.5333, 0.5189, 0.5181, 0.5176, 0.5172, 0.5119)`
+- const `HE_B = (0.477, 0.5747, 0.6527, 0.7223, 0.7582, 0.7957, 0.8279, 0.8553, 0.8757, 0.8903, 0.8997, 0.9073, 0.9122, 0.9171, 0.9217, 0.9267)`
+- const `COMPARTMENT_COUNT = 16`
+### class `ZHL16State` (DecoState) — Frozen snapshot of the 16 (ppn2, pphe) tissue tensions in float mbar.
+  `__slots__ = ('tissues',)`
+  - `__init__(self, tissues: tuple[tuple[float, float], ...])`
+  attrs: `tissues: tuple[tuple[float, float], ...]`
+  dunders: `__delattr__, __eq__, __hash__, __repr__, __setattr__`
+### class `ZHL16C` (BaseDecoModel[ZHL16State]) — Bühlmann ZHL-16C with Baker gradient factors.
+  `__slots__ = ('gradient', '_compartments')`
+  - `__init__(self, gradient: Gradient | None = None)`
+  - `_integrate_model(self, pressure: Pressure, gas: Gas, dt: timedelta) -> None`
+  - `_get_deco_state(self) -> ZHL16State`
+  - `get_ceiling(self, gradient_factor: float | None = None) -> Pressure`  — Minimum tolerated ambient pressure across all compartments.
+  - `set_state(self, state: ZHL16State) -> None`  — Restore tissue tensions from a snapshot (exact, lossless).
+  - `copy(self) -> 'ZHL16C'`  — Independent clone with the same gradient and tissue tensions —
+  attrs: `NAME = 'zhl16c'; gradient: Gradient`
+  dunders: `__repr__`
 
 ## `src/diveplan/planning/__init__.py`
 (empty stub)
@@ -310,6 +339,7 @@ Decompression model base classes.
 
 # Tests (tests/)
 - `conftest.py` (0 tests)
+- `test_buhlmann.py` (38 tests) — TestGradient, TestCompartmentState, TestCompartmentIntegration, TestCompartmentToleratedPressure, TestZHL16CTables, TestZHL16CModel, TestZHL16CRegistry
 - `test_config.py` (45 tests) — TestSubConfigBase, TestPhysicsConfig, TestGasConfig, TestDivePlanningConfig, TestDiveConfigStructure, TestGlobalDefault, TestContextManager, TestDefaultConfigLoading, TestSerialization
 - `test_dive_profile.py` (74 tests) — TestDiveProfileBuilder, TestDiveProfileValidation, TestDiveProfileFixes, TestDiveProfileTimeline, TestDiveProfileFluentBuilders, TestDiveProfileSerialization
 - `test_dive_segment.py` (59 tests) — TestDiveSegmentConstruction, TestDiveSegmentProperties, TestDiveSegmentInterpolation, TestDiveSegmentSplitting, TestDiveSegmentMerging, TestDiveSegmentContinuity, TestDiveSegmentIteration, TestDiveSegmentMagicMethods, TestDiveSegmentImmutability, TestDiveSegmentSerialization

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,9 @@ dev = ["pytest", "pytest-cov", "ruff", "mypy"]
 # in the group, so an entry must only be registered once its module exists —
 # a dangling reference would break all model lookups.
 #
-# Uncomment when diveplan/models/buhlmann/zhl16.py lands:
-# [project.entry-points."diveplan.deco_models"]
-# zhl16c = "diveplan.models.buhlmann.zhl16:ZHL16C"
-#
+[project.entry-points."diveplan.deco_models"]
+zhl16c = "diveplan.models.buhlmann.zhl16:ZHL16C"
+
 # Uncomment when the formatter modules land:
 # [project.entry-points."diveplan.formatters"]
 # json = "diveplan.dive.formatters.json:JSONFormatter"

--- a/src/diveplan/models/buhlmann/__init__.py
+++ b/src/diveplan/models/buhlmann/__init__.py
@@ -1,6 +1,12 @@
-"""Bühlmann decompression models and shared helpers."""
+"""Bühlmann-family decompression models.
+
+The shared algorithm lives in :class:`BuhlmannModel` (``model.py``) over the
+helpers in ``common.py`` (:class:`Compartment`, :class:`Gradient`). Concrete
+variants (``zhl16.py``) supply only their coefficient tables.
+"""
 
 from diveplan.models.buhlmann.common import Compartment, Gradient
-from diveplan.models.buhlmann.zhl16 import ZHL16C, ZHL16State
+from diveplan.models.buhlmann.model import BuhlmannModel, BuhlmannState
+from diveplan.models.buhlmann.zhl16 import ZHL16C
 
-__all__ = ["ZHL16C", "ZHL16State", "Compartment", "Gradient"]
+__all__ = ["BuhlmannModel", "BuhlmannState", "ZHL16C", "Compartment", "Gradient"]

--- a/src/diveplan/models/buhlmann/__init__.py
+++ b/src/diveplan/models/buhlmann/__init__.py
@@ -1,0 +1,6 @@
+"""Bühlmann decompression models and shared helpers."""
+
+from diveplan.models.buhlmann.common import Compartment, Gradient
+from diveplan.models.buhlmann.zhl16 import ZHL16C, ZHL16State
+
+__all__ = ["ZHL16C", "ZHL16State", "Compartment", "Gradient"]

--- a/src/diveplan/models/buhlmann/common.py
+++ b/src/diveplan/models/buhlmann/common.py
@@ -1,22 +1,55 @@
+"""Shared Bühlmann machinery: gradient factors and Haldane tissue compartments.
+
+Unit conventions
+----------------
+- Bühlmann ``a`` coefficients are published in **bar**; they are converted to
+  mbar internally. ``b`` coefficients are dimensionless.
+- Tissue tensions are tracked as **float mbar** internally, not integer-mbar
+  :class:`Pressure`: at fine sample rates (1 s) a slow compartment's per-step
+  change is far below 1 mbar, and integer quantization would silently freeze
+  it. ``Pressure`` remains the boundary type for all inputs and outputs.
+- Alveolar (inspired) inert-gas pressure subtracts water vapor at body
+  temperature: ``(P_amb − 62.7 mbar) · fraction`` (Bühlmann's 0.0627 bar).
+
+Gradient factors follow Erik Baker's convention: GF-low applies at the first
+(deepest) stop, GF-high at the surface, interpolated linearly in ambient
+pressure between the two. Factors are fractions (``Gradient(0.3, 0.85)`` is
+GF 30/85); ``Gradient(1.0, 1.0)`` is raw Bühlmann.
+"""
+
 from datetime import timedelta
 from typing import Optional
 
 from diveplan.core.gas import Gas
 from diveplan.core.pressure import Pressure
 
-__all__ = "Gradient", "Compartment"
+__all__ = ("Gradient", "Compartment", "WATER_VAPOR_PRESSURE_MBAR")
+
+# Alveolar water vapor pressure at 37 °C (Bühlmann: 0.0627 bar).
+WATER_VAPOR_PRESSURE_MBAR = 62.7
+
+# Inert-gas fraction of dry air used for default surface equilibrium.
+_AIR_FN2 = 0.79
 
 
 class Gradient:
-    """Helper for computing gradients of dive segments."""
+    """A gradient-factor pair (Baker GF low/high), as fractions.
 
-    __slots__ = "gf_low", "gf_high"
+    GF-low is the allowed fraction of the Bühlmann M-value gradient at the
+    first (deepest) stop; GF-high applies at the surface. ``factor()``
+    interpolates linearly in ambient pressure between the two.
+    """
 
-    # For type annotations only, since these are set in __init__ and not declared as class variables.
+    __slots__ = ("gf_low", "gf_high")
+
     gf_low: float
     gf_high: float
 
     def __init__(self, gf_low: float, gf_high: float):
+        if gf_low <= 0 or gf_high <= 0:
+            raise ValueError(
+                f"Gradient factors must be > 0, got gf_low={gf_low}, gf_high={gf_high}."
+            )
         self.gf_low = gf_low
         self.gf_high = gf_high
 
@@ -24,7 +57,7 @@ class Gradient:
         return f"Gradient(gf_low={self.gf_low}, gf_high={self.gf_high})"
 
     def __str__(self) -> str:
-        return f"GF Low: {self.gf_low}%, GF High: {self.gf_high}%"
+        return f"GF {round(self.gf_low * 100)}/{round(self.gf_high * 100)}"
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Gradient):
@@ -34,46 +67,51 @@ class Gradient:
     def __hash__(self) -> int:
         return hash((self.gf_low, self.gf_high))
 
-    def factor(self, depth_pressure: Pressure, max_depth_pressure: Pressure) -> float:
-        """Linearly interpolate the gradient for a given depth."""
-        if self.gf_low == self.gf_high:
-            return self.gf_low
+    def factor(self, pressure: Pressure, first_stop_pressure: Pressure) -> float:
+        """Gradient factor applicable at ``pressure``.
 
-        if depth_pressure.is_surface:
+        Returns gf_low at (and below) the first stop, gf_high at (and above)
+        the surface, linear in ambient pressure in between. Continuous over
+        the whole range. Reads the current surface pressure from config.
+        """
+        surface = Pressure.surface()
+        if pressure >= first_stop_pressure:
             return self.gf_low
-
-        elif depth_pressure >= max_depth_pressure:
+        if pressure <= surface or first_stop_pressure <= surface:
             return self.gf_high
 
-        else:
-            return self.gf_low + (self.gf_high - self.gf_low) * (
-                depth_pressure / max_depth_pressure
-            )
+        fraction = (pressure - surface) / (first_stop_pressure - surface)
+        return self.gf_high + (self.gf_low - self.gf_high) * fraction
 
 
 class Compartment:
-    """Helper for tracking compartment constants and saturation."""
+    """One Haldane tissue compartment with Bühlmann a/b coefficients.
+
+    Holds the compartment constants (N2/He half-times in minutes, ``a`` in
+    bar, ``b`` dimensionless) and the current inert-gas tensions. Fresh
+    compartments default to surface equilibrium on air: N2 at
+    ``(P_surface − P_H2O) · 0.79``, He at zero.
+    """
 
     __slots__ = (
-        "ppn2",
-        "pphe",
         "ht_n2",
         "ht_he",
         "a_n2",
         "a_he",
         "b_n2",
         "b_he",
-        "tolerated_pressure",
+        "_ppn2_mbar",
+        "_pphe_mbar",
     )
 
-    ppn2: Pressure
-    pphe: Pressure
     ht_n2: float
     ht_he: float
     a_n2: float
     a_he: float
     b_n2: float
     b_he: float
+    _ppn2_mbar: float
+    _pphe_mbar: float
 
     def __init__(
         self,
@@ -87,14 +125,11 @@ class Compartment:
         ppn2: Optional[Pressure] = None,
         pphe: Optional[Pressure] = None,
     ):
+        if ht_n2 <= 0 or ht_he <= 0:
+            raise ValueError(f"Half-times must be > 0, got {ht_n2=}, {ht_he=}.")
+        if b_n2 <= 0 or b_he <= 0:
+            raise ValueError(f"b coefficients must be > 0, got {b_n2=}, {b_he=}.")
 
-        if ppn2 is None:
-            ppn2 = Pressure.surface()
-        if pphe is None:
-            pphe = Pressure.surface()
-
-        self.ppn2 = ppn2
-        self.pphe = pphe
         self.ht_n2 = ht_n2
         self.ht_he = ht_he
         self.a_n2 = a_n2
@@ -102,89 +137,111 @@ class Compartment:
         self.b_n2 = b_n2
         self.b_he = b_he
 
-    def update_compartment(
-        self,
-        pressure: Pressure,
-        gas: Gas,
-        duration: timedelta,
-        gradient_factor: float,
-    ):
+        if ppn2 is not None:
+            self._ppn2_mbar = float(ppn2.mbar)
+        else:
+            surface = Pressure.surface()
+            self._ppn2_mbar = (surface.mbar - WATER_VAPOR_PRESSURE_MBAR) * _AIR_FN2
+        self._pphe_mbar = float(pphe.mbar) if pphe is not None else 0.0
 
-        self._integrate_compartment(pressure, gas, duration)
-        self._update_compartment_max_tolerated_pressure(pressure, gradient_factor)
+    # ------------------------------------------------------------------
+    # State access
+    # ------------------------------------------------------------------
 
-    def _integrate_compartment(self, pressure: Pressure, gas: Gas, duration: timedelta):
-        gas_ppn2 = gas.ppo2(pressure)
-        gas_pphe = gas.pphe(pressure)
+    @property
+    def ppn2(self) -> Pressure:
+        """Current N2 tension (rounded to integer mbar for display/compare)."""
+        return Pressure.from_mbar(self._ppn2_mbar)
 
-        duration_minutes = duration.total_seconds() / 60.0
+    @property
+    def pphe(self) -> Pressure:
+        """Current He tension (rounded to integer mbar for display/compare)."""
+        return Pressure.from_mbar(self._pphe_mbar)
 
-        self.ppn2 = self._calc_inert_gas_pressure(
-            self.ppn2, gas_ppn2, duration_minutes, self.ht_n2
+    @property
+    def tensions_mbar(self) -> tuple[float, float]:
+        """Exact (ppn2, pphe) tensions in float mbar — for state snapshots."""
+        return (self._ppn2_mbar, self._pphe_mbar)
+
+    def set_tensions_mbar(self, ppn2_mbar: float, pphe_mbar: float) -> None:
+        """Restore exact tensions from a state snapshot."""
+        if ppn2_mbar < 0 or pphe_mbar < 0:
+            raise ValueError(
+                f"Tensions cannot be negative, got {ppn2_mbar=}, {pphe_mbar=}."
+            )
+        self._ppn2_mbar = ppn2_mbar
+        self._pphe_mbar = pphe_mbar
+
+    def copy(self) -> "Compartment":
+        """Independent copy with the same constants and current tensions."""
+        clone = Compartment(
+            ht_n2=self.ht_n2,
+            ht_he=self.ht_he,
+            a_n2=self.a_n2,
+            a_he=self.a_he,
+            b_n2=self.b_n2,
+            b_he=self.b_he,
+        )
+        clone.set_tensions_mbar(self._ppn2_mbar, self._pphe_mbar)
+        return clone
+
+    # ------------------------------------------------------------------
+    # Integration
+    # ------------------------------------------------------------------
+
+    def integrate(self, pressure: Pressure, gas: Gas, duration: timedelta) -> None:
+        """Haldane exponential update toward the alveolar inert pressures.
+
+        ``P(t+Δt) = P(t) + (P_alv − P(t)) · (1 − 2^(−Δt/ht))`` per inert gas,
+        with ``P_alv = (P_amb − P_H2O) · fraction``.
+        """
+        minutes = duration.total_seconds() / 60.0
+        alveolar_mbar = pressure.mbar - WATER_VAPOR_PRESSURE_MBAR
+
+        self._ppn2_mbar += (alveolar_mbar * gas.fn2 - self._ppn2_mbar) * (
+            1.0 - 2.0 ** (-minutes / self.ht_n2)
+        )
+        self._pphe_mbar += (alveolar_mbar * gas.fhe - self._pphe_mbar) * (
+            1.0 - 2.0 ** (-minutes / self.ht_he)
         )
 
-        self.pphe = self._calc_inert_gas_pressure(
-            self.pphe, gas_pphe, duration_minutes, self.ht_he
+    # ------------------------------------------------------------------
+    # Tolerated ambient pressure (ceiling contribution)
+    # ------------------------------------------------------------------
+
+    def tolerated_ambient_pressure(self, gradient_factor: float = 1.0) -> Pressure:
+        """Minimum ambient pressure this compartment tolerates (Baker formula).
+
+        ``P_amb_tol = (P_t − a·GF) / (GF/b + 1 − GF)`` with tension-weighted
+        a/b for the N2/He mix. At GF = 1 this reduces to Bühlmann's
+        ``(P_t − a) · b``. Clamped at zero (a fully desaturated compartment
+        tolerates any ambient pressure).
+        """
+        if gradient_factor <= 0:
+            raise ValueError(f"gradient_factor must be > 0, got {gradient_factor}.")
+
+        total = self._ppn2_mbar + self._pphe_mbar
+        if total <= 0:
+            return Pressure(0)
+
+        # Tension-weighted coefficients; a converted bar -> mbar.
+        a_mbar = 1000.0 * (
+            (self.a_n2 * self._ppn2_mbar + self.a_he * self._pphe_mbar) / total
         )
+        b = (self.b_n2 * self._ppn2_mbar + self.b_he * self._pphe_mbar) / total
 
-    def _update_compartment_max_tolerated_pressure(
-        self, ambiant_pressure: Pressure, gradient_factor: float
-    ):
-        self.tolerated_pressure = self._calcInertGasLimit(
-            self.ppn2,
-            self.pphe,
-            self.a_n2,
-            self.b_n2,
-            self.a_he,
-            self.b_he,
-            ambiant_pressure,
-            gradient_factor,
+        tolerated = (total - a_mbar * gradient_factor) / (
+            gradient_factor / b + 1.0 - gradient_factor
         )
+        return Pressure.from_mbar(max(0.0, tolerated))
 
-    @staticmethod
-    def _calc_inert_gas_pressure(
-        ambiant_pressure: Pressure,
-        inspired_gas_pressure: Pressure,
-        time_minutes: float,
-        half_time_minutes: float,
-    ) -> Pressure:
-        return ambiant_pressure + (inspired_gas_pressure - ambiant_pressure) * (
-            1 - 2 ** (-time_minutes / half_time_minutes)
-        )
-
-    @staticmethod
-    def _calcInertGasLimit(
-        ppn2: Pressure,
-        pphe: Pressure,
-        a_n2: float,
-        b_n2: float,
-        a_he: float,
-        b_he: float,
-        ambiant_pressure: Pressure,
-        gradient_factor: float,
-    ) -> Pressure:
-
-        inert_pressure = ppn2 + pphe
-        inert_gas_ratio = pphe / inert_pressure
-
-        a = a_n2 * (1 - inert_gas_ratio) + a_he * inert_gas_ratio
-        b = b_n2 * (1 - inert_gas_ratio) + b_he * inert_gas_ratio
-
-        max_tolerated_pressure = (inert_pressure - a) * b
-        return ambiant_pressure + gradient_factor * (
-            max_tolerated_pressure - ambiant_pressure.mbar
-        )
-
-    def is_eq_pressures_only(self, other: Compartment) -> bool:
-        return self.ppn2 == other.ppn2 and self.pphe == other.pphe
-
-    def is_eq_with_pressures(self, other: Compartment) -> bool:
-        return self.is_eq_pressures_only(other) and self == other
+    # ------------------------------------------------------------------
+    # Dunder
+    # ------------------------------------------------------------------
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Compartment):
             return NotImplemented
-
         return (
             self.ht_n2 == other.ht_n2
             and self.ht_he == other.ht_he
@@ -192,24 +249,29 @@ class Compartment:
             and self.a_he == other.a_he
             and self.b_n2 == other.b_n2
             and self.b_he == other.b_he
+            and self._ppn2_mbar == other._ppn2_mbar
+            and self._pphe_mbar == other._pphe_mbar
         )
 
     def __hash__(self) -> int:
         return hash(
             (
-                self.ppn2,
-                self.pphe,
                 self.ht_n2,
                 self.ht_he,
                 self.a_n2,
                 self.a_he,
                 self.b_n2,
                 self.b_he,
+                self._ppn2_mbar,
+                self._pphe_mbar,
             )
         )
 
     def __repr__(self) -> str:
-        return f"Compartment(ppn2={self.ppn2}, pphe={self.pphe})"
+        return (
+            f"Compartment(ht_n2={self.ht_n2}, ppn2={self._ppn2_mbar:.1f} mbar, "
+            f"pphe={self._pphe_mbar:.1f} mbar)"
+        )
 
     def __str__(self) -> str:
         return f"PPN2: {self.ppn2}, PPHE: {self.pphe}"

--- a/src/diveplan/models/buhlmann/model.py
+++ b/src/diveplan/models/buhlmann/model.py
@@ -1,0 +1,202 @@
+"""Generic Bühlmann decompression engine.
+
+All Bühlmann-family models share the same algorithm — parallel Haldane
+compartments integrated toward alveolar inert-gas pressures, with a ceiling
+from the a/b M-value line (optionally scaled by Baker gradient factors).
+Variants differ only in their coefficient tables: number of compartments,
+half-times, and a/b values.
+
+:class:`BuhlmannModel` implements the whole algorithm; a concrete model
+(e.g. :class:`~diveplan.models.buhlmann.zhl16.ZHL16C`) supplies only ``NAME``
+and the six class-level tables. Table consistency is validated at class
+definition time. Running without gradient factors is the default
+(``Gradient(1.0, 1.0)`` — raw Bühlmann); pass a :class:`Gradient` for GF.
+"""
+
+from datetime import timedelta
+from typing import ClassVar, Self
+
+from diveplan.core.config import DiveConfig
+from diveplan.core.gas import Gas
+from diveplan.core.pressure import Pressure
+from diveplan.models.base import BaseDecoModel, DecoState
+from diveplan.models.buhlmann.common import Compartment, Gradient
+
+__all__ = ["BuhlmannModel", "BuhlmannState"]
+
+_TABLE_NAMES = ("N2_HALF_TIMES", "N2_A", "N2_B", "HE_HALF_TIMES", "HE_A", "HE_B")
+
+
+class BuhlmannState(DecoState):
+    """Frozen snapshot of (ppn2, pphe) tissue tensions in float mbar.
+
+    Shared by all Bühlmann-family models; the tuple length equals the
+    model's compartment count.
+    """
+
+    __slots__ = ("tissues",)
+
+    tissues: tuple[tuple[float, float], ...]
+
+    def __init__(self, tissues: tuple[tuple[float, float], ...]):
+        if not tissues:
+            raise ValueError("BuhlmannState needs at least one tissue tension pair.")
+        object.__setattr__(self, "tissues", tissues)
+
+    def __setattr__(self, name: str, value: object) -> None:
+        raise AttributeError("BuhlmannState is immutable.")
+
+    def __delattr__(self, name: str) -> None:
+        raise AttributeError("BuhlmannState is immutable.")
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, BuhlmannState):
+            return NotImplemented
+        return self.tissues == other.tissues
+
+    def __hash__(self) -> int:
+        return hash(self.tissues)
+
+    def __repr__(self) -> str:
+        leading = ", ".join(f"({n:.0f}, {h:.0f})" for n, h in self.tissues[:3])
+        return (
+            f"BuhlmannState({len(self.tissues)} compartments, "
+            f"tissues=[{leading}, …] mbar)"
+        )
+
+
+class BuhlmannModel(BaseDecoModel[BuhlmannState]):
+    """Bühlmann algorithm over a subclass-supplied coefficient table.
+
+    Subclasses define ``NAME`` and the six tables (half-times in minutes,
+    ``a`` in bar, ``b`` dimensionless), all of equal length::
+
+        class ZHL16C(BuhlmannModel):
+            NAME = "zhl16c"
+            N2_HALF_TIMES = (5.0, 8.0, ...)
+            ...
+
+    Fresh instances start at surface equilibrium on air. The sample rate is
+    read from ``DiveConfig.current().planning.sample_rate_s`` at construction.
+
+    Args:
+        gradient: GF pair; defaults to ``Gradient(1.0, 1.0)`` (raw Bühlmann).
+    """
+
+    # Coefficient tables — supplied by concrete subclasses.
+    N2_HALF_TIMES: ClassVar[tuple[float, ...]]
+    N2_A: ClassVar[tuple[float, ...]]
+    N2_B: ClassVar[tuple[float, ...]]
+    HE_HALF_TIMES: ClassVar[tuple[float, ...]]
+    HE_A: ClassVar[tuple[float, ...]]
+    HE_B: ClassVar[tuple[float, ...]]
+
+    __slots__ = ("gradient", "_compartments")
+
+    gradient: Gradient
+    _compartments: list[Compartment]
+
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        """Validate coefficient tables at class definition time."""
+        super().__init_subclass__(**kwargs)
+        defined = [name for name in _TABLE_NAMES if hasattr(cls, name)]
+        if not defined:
+            return  # abstract intermediate subclass — tables come later
+        missing = [name for name in _TABLE_NAMES if name not in defined]
+        if missing:
+            raise TypeError(
+                f"{cls.__name__} defines {defined} but is missing {missing}."
+            )
+        lengths = {name: len(getattr(cls, name)) for name in _TABLE_NAMES}
+        if len(set(lengths.values())) != 1:
+            raise TypeError(
+                f"{cls.__name__} coefficient tables have mismatched lengths: {lengths}."
+            )
+        if 0 in lengths.values():
+            raise TypeError(f"{cls.__name__} coefficient tables are empty.")
+
+    def __init__(self, gradient: Gradient | None = None):
+        if not hasattr(type(self), "N2_HALF_TIMES"):
+            raise TypeError(
+                "BuhlmannModel is an abstract engine — instantiate a concrete "
+                "model (e.g. ZHL16C) that supplies coefficient tables."
+            )
+        super().__init__()
+        self.sample_rate_seconds = DiveConfig.current().planning.sample_rate_s
+        self.gradient = gradient if gradient is not None else Gradient(1.0, 1.0)
+        self._compartments = [
+            Compartment(
+                ht_n2=self.N2_HALF_TIMES[i],
+                ht_he=self.HE_HALF_TIMES[i],
+                a_n2=self.N2_A[i],
+                a_he=self.HE_A[i],
+                b_n2=self.N2_B[i],
+                b_he=self.HE_B[i],
+            )
+            for i in range(self.compartment_count)
+        ]
+
+    @property
+    def compartment_count(self) -> int:
+        """Number of tissue compartments in this model's table."""
+        return len(self.N2_HALF_TIMES)
+
+    # ------------------------------------------------------------------
+    # BaseDecoModel contract
+    # ------------------------------------------------------------------
+
+    def _integrate_model(self, pressure: Pressure, gas: Gas, dt: timedelta) -> None:
+        for compartment in self._compartments:
+            compartment.integrate(pressure, gas, dt)
+
+    def _get_deco_state(self) -> BuhlmannState:
+        return BuhlmannState(tuple(c.tensions_mbar for c in self._compartments))
+
+    def get_ceiling(self, gradient_factor: float | None = None) -> Pressure:
+        """Minimum tolerated ambient pressure across all compartments.
+
+        A ceiling above surface pressure means decompression stops are
+        required. Defaults to GF-low (the conservative bound during the deep
+        phase); the ascent planner passes interpolated factors from
+        ``Gradient.factor()`` as the diver approaches the surface.
+        """
+        gf = gradient_factor if gradient_factor is not None else self.gradient.gf_low
+        return max(c.tolerated_ambient_pressure(gf) for c in self._compartments)
+
+    # ------------------------------------------------------------------
+    # State snapshot / restore (checkpointing, counterfactual queries)
+    # ------------------------------------------------------------------
+
+    def set_state(self, state: BuhlmannState) -> None:
+        """Restore tissue tensions from a snapshot (exact, lossless).
+
+        Raises:
+            ValueError: If the snapshot's compartment count does not match
+                this model's table.
+        """
+        if len(state.tissues) != self.compartment_count:
+            raise ValueError(
+                f"State has {len(state.tissues)} compartments, "
+                f"{type(self).__name__} has {self.compartment_count}."
+            )
+        for compartment, (ppn2, pphe) in zip(
+            self._compartments, state.tissues, strict=True
+        ):
+            compartment.set_tensions_mbar(ppn2, pphe)
+
+    def copy(self) -> Self:
+        """Independent clone with the same gradient and tissue tensions —
+        for hypothetical ascents (TTS queries) without disturbing the run.
+
+        Subclasses that change the ``__init__`` signature must override.
+        """
+        clone = type(self)(gradient=self.gradient)
+        clone.sample_rate_seconds = self.sample_rate_seconds
+        clone.set_state(self._get_deco_state())
+        return clone
+
+    def __repr__(self) -> str:
+        return (
+            f"{type(self).__name__}(gradient={self.gradient!r}, "
+            f"ceiling={self.get_ceiling()})"
+        )

--- a/src/diveplan/models/buhlmann/zhl16.py
+++ b/src/diveplan/models/buhlmann/zhl16.py
@@ -1,0 +1,164 @@
+"""Bühlmann ZHL-16C decompression model.
+
+Sixteen parallel Haldane compartments (the 1b variant of the first
+compartment, 5.0 min N2 half-time — the set used by most implementations).
+Coefficient tables are the published ZHL-16C values: half-times in minutes,
+``a`` in bar, ``b`` dimensionless.
+
+The model is generic over :class:`ZHL16State` — a frozen snapshot of the 16
+(N2, He) tissue tensions in float mbar (see ``common.py`` for why tensions
+are floats, not integer-mbar Pressures).
+"""
+
+from datetime import timedelta
+
+from diveplan.core.config import DiveConfig
+from diveplan.core.gas import Gas
+from diveplan.core.pressure import Pressure
+from diveplan.models.base import BaseDecoModel, DecoState
+from diveplan.models.buhlmann.common import Compartment, Gradient
+
+__all__ = ["ZHL16C", "ZHL16State"]
+
+# ZHL-16C coefficient tables (compartment 1b first). Sources: Bühlmann,
+# Tauchmedizin; identical values are used by Subsurface/OSTC.
+# fmt: off
+N2_HALF_TIMES = (
+    5.0, 8.0, 12.5, 18.5, 27.0, 38.3, 54.3, 77.0,
+    109.0, 146.0, 187.0, 239.0, 305.0, 390.0, 498.0, 635.0,
+)
+N2_A = (
+    1.1696, 1.0000, 0.8618, 0.7562, 0.6200, 0.5043, 0.4410, 0.4000,
+    0.3750, 0.3500, 0.3295, 0.3065, 0.2835, 0.2610, 0.2480, 0.2327,
+)
+N2_B = (
+    0.5578, 0.6514, 0.7222, 0.7825, 0.8126, 0.8434, 0.8693, 0.8910,
+    0.9092, 0.9222, 0.9319, 0.9403, 0.9477, 0.9544, 0.9602, 0.9653,
+)
+HE_HALF_TIMES = (
+    1.88, 3.02, 4.72, 6.99, 10.21, 14.48, 20.53, 29.11,
+    41.20, 55.19, 70.69, 90.34, 115.29, 147.42, 188.24, 240.03,
+)
+HE_A = (
+    1.6189, 1.3830, 1.1919, 1.0458, 0.9220, 0.8205, 0.7305, 0.6502,
+    0.5950, 0.5545, 0.5333, 0.5189, 0.5181, 0.5176, 0.5172, 0.5119,
+)
+HE_B = (
+    0.4770, 0.5747, 0.6527, 0.7223, 0.7582, 0.7957, 0.8279, 0.8553,
+    0.8757, 0.8903, 0.8997, 0.9073, 0.9122, 0.9171, 0.9217, 0.9267,
+)
+# fmt: on
+
+COMPARTMENT_COUNT = 16
+
+
+class ZHL16State(DecoState):
+    """Frozen snapshot of the 16 (ppn2, pphe) tissue tensions in float mbar."""
+
+    __slots__ = ("tissues",)
+
+    tissues: tuple[tuple[float, float], ...]
+
+    def __init__(self, tissues: tuple[tuple[float, float], ...]):
+        if len(tissues) != COMPARTMENT_COUNT:
+            raise ValueError(
+                f"ZHL16State needs {COMPARTMENT_COUNT} tissue tension pairs, "
+                f"got {len(tissues)}."
+            )
+        object.__setattr__(self, "tissues", tissues)
+
+    def __setattr__(self, name: str, value: object) -> None:
+        raise AttributeError("ZHL16State is immutable.")
+
+    def __delattr__(self, name: str) -> None:
+        raise AttributeError("ZHL16State is immutable.")
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ZHL16State):
+            return NotImplemented
+        return self.tissues == other.tissues
+
+    def __hash__(self) -> int:
+        return hash(self.tissues)
+
+    def __repr__(self) -> str:
+        leading = ", ".join(f"({n:.0f}, {h:.0f})" for n, h in self.tissues[:3])
+        return f"ZHL16State(tissues=[{leading}, …] mbar)"
+
+
+class ZHL16C(BaseDecoModel[ZHL16State]):
+    """Bühlmann ZHL-16C with Baker gradient factors.
+
+    Fresh instances start at surface equilibrium on air. The sample rate is
+    read from ``DiveConfig.current().planning.sample_rate_s`` at construction.
+
+    Args:
+        gradient: GF pair; defaults to ``Gradient(1.0, 1.0)`` (raw Bühlmann).
+    """
+
+    NAME = "zhl16c"
+
+    __slots__ = ("gradient", "_compartments")
+
+    gradient: Gradient
+    _compartments: list[Compartment]
+
+    def __init__(self, gradient: Gradient | None = None):
+        super().__init__()
+        self.sample_rate_seconds = DiveConfig.current().planning.sample_rate_s
+        self.gradient = gradient if gradient is not None else Gradient(1.0, 1.0)
+        self._compartments = [
+            Compartment(
+                ht_n2=N2_HALF_TIMES[i],
+                ht_he=HE_HALF_TIMES[i],
+                a_n2=N2_A[i],
+                a_he=HE_A[i],
+                b_n2=N2_B[i],
+                b_he=HE_B[i],
+            )
+            for i in range(COMPARTMENT_COUNT)
+        ]
+
+    # ------------------------------------------------------------------
+    # BaseDecoModel contract
+    # ------------------------------------------------------------------
+
+    def _integrate_model(self, pressure: Pressure, gas: Gas, dt: timedelta) -> None:
+        for compartment in self._compartments:
+            compartment.integrate(pressure, gas, dt)
+
+    def _get_deco_state(self) -> ZHL16State:
+        return ZHL16State(tuple(c.tensions_mbar for c in self._compartments))
+
+    def get_ceiling(self, gradient_factor: float | None = None) -> Pressure:
+        """Minimum tolerated ambient pressure across all compartments.
+
+        A ceiling above surface pressure means decompression stops are
+        required. Defaults to GF-low (the conservative bound during the deep
+        phase); the ascent planner passes interpolated factors from
+        ``Gradient.factor()`` as the diver approaches the surface.
+        """
+        gf = gradient_factor if gradient_factor is not None else self.gradient.gf_low
+        return max(c.tolerated_ambient_pressure(gf) for c in self._compartments)
+
+    # ------------------------------------------------------------------
+    # State snapshot / restore (checkpointing, counterfactual queries)
+    # ------------------------------------------------------------------
+
+    def set_state(self, state: ZHL16State) -> None:
+        """Restore tissue tensions from a snapshot (exact, lossless)."""
+        for compartment, (ppn2, pphe) in zip(
+            self._compartments, state.tissues, strict=True
+        ):
+            compartment.set_tensions_mbar(ppn2, pphe)
+
+    def copy(self) -> "ZHL16C":
+        """Independent clone with the same gradient and tissue tensions —
+        for hypothetical ascents (TTS queries) without disturbing the run."""
+        clone = ZHL16C(gradient=self.gradient)
+        clone.sample_rate_seconds = self.sample_rate_seconds
+        clone.set_state(self._get_deco_state())
+        return clone
+
+    def __repr__(self) -> str:
+        return f"ZHL16C(gradient={self.gradient!r}, ceiling={self.get_ceiling()})"

--- a/src/diveplan/models/buhlmann/zhl16.py
+++ b/src/diveplan/models/buhlmann/zhl16.py
@@ -1,164 +1,50 @@
-"""Bühlmann ZHL-16C decompression model.
+"""Bühlmann ZHL-16 variants — coefficient tables over the shared engine.
 
-Sixteen parallel Haldane compartments (the 1b variant of the first
-compartment, 5.0 min N2 half-time — the set used by most implementations).
-Coefficient tables are the published ZHL-16C values: half-times in minutes,
-``a`` in bar, ``b`` dimensionless.
-
-The model is generic over :class:`ZHL16State` — a frozen snapshot of the 16
-(N2, He) tissue tensions in float mbar (see ``common.py`` for why tensions
-are floats, not integer-mbar Pressures).
+The whole algorithm lives in :class:`~diveplan.models.buhlmann.model.BuhlmannModel`;
+a variant is nothing but ``NAME`` plus its published tables (half-times in
+minutes, ``a`` in bar, ``b`` dimensionless). ZHL-16A/16B can be added the
+same way once their tables are transcribed and verified.
 """
 
-from datetime import timedelta
+from diveplan.models.buhlmann.model import BuhlmannModel, BuhlmannState
 
-from diveplan.core.config import DiveConfig
-from diveplan.core.gas import Gas
-from diveplan.core.pressure import Pressure
-from diveplan.models.base import BaseDecoModel, DecoState
-from diveplan.models.buhlmann.common import Compartment, Gradient
-
-__all__ = ["ZHL16C", "ZHL16State"]
-
-# ZHL-16C coefficient tables (compartment 1b first). Sources: Bühlmann,
-# Tauchmedizin; identical values are used by Subsurface/OSTC.
-# fmt: off
-N2_HALF_TIMES = (
-    5.0, 8.0, 12.5, 18.5, 27.0, 38.3, 54.3, 77.0,
-    109.0, 146.0, 187.0, 239.0, 305.0, 390.0, 498.0, 635.0,
-)
-N2_A = (
-    1.1696, 1.0000, 0.8618, 0.7562, 0.6200, 0.5043, 0.4410, 0.4000,
-    0.3750, 0.3500, 0.3295, 0.3065, 0.2835, 0.2610, 0.2480, 0.2327,
-)
-N2_B = (
-    0.5578, 0.6514, 0.7222, 0.7825, 0.8126, 0.8434, 0.8693, 0.8910,
-    0.9092, 0.9222, 0.9319, 0.9403, 0.9477, 0.9544, 0.9602, 0.9653,
-)
-HE_HALF_TIMES = (
-    1.88, 3.02, 4.72, 6.99, 10.21, 14.48, 20.53, 29.11,
-    41.20, 55.19, 70.69, 90.34, 115.29, 147.42, 188.24, 240.03,
-)
-HE_A = (
-    1.6189, 1.3830, 1.1919, 1.0458, 0.9220, 0.8205, 0.7305, 0.6502,
-    0.5950, 0.5545, 0.5333, 0.5189, 0.5181, 0.5176, 0.5172, 0.5119,
-)
-HE_B = (
-    0.4770, 0.5747, 0.6527, 0.7223, 0.7582, 0.7957, 0.8279, 0.8553,
-    0.8757, 0.8903, 0.8997, 0.9073, 0.9122, 0.9171, 0.9217, 0.9267,
-)
-# fmt: on
-
-COMPARTMENT_COUNT = 16
+__all__ = ["ZHL16C", "BuhlmannState"]
 
 
-class ZHL16State(DecoState):
-    """Frozen snapshot of the 16 (ppn2, pphe) tissue tensions in float mbar."""
+class ZHL16C(BuhlmannModel):
+    """Bühlmann ZHL-16C, 16 compartments (1b first-compartment variant).
 
-    __slots__ = ("tissues",)
-
-    tissues: tuple[tuple[float, float], ...]
-
-    def __init__(self, tissues: tuple[tuple[float, float], ...]):
-        if len(tissues) != COMPARTMENT_COUNT:
-            raise ValueError(
-                f"ZHL16State needs {COMPARTMENT_COUNT} tissue tension pairs, "
-                f"got {len(tissues)}."
-            )
-        object.__setattr__(self, "tissues", tissues)
-
-    def __setattr__(self, name: str, value: object) -> None:
-        raise AttributeError("ZHL16State is immutable.")
-
-    def __delattr__(self, name: str) -> None:
-        raise AttributeError("ZHL16State is immutable.")
-
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, ZHL16State):
-            return NotImplemented
-        return self.tissues == other.tissues
-
-    def __hash__(self) -> int:
-        return hash(self.tissues)
-
-    def __repr__(self) -> str:
-        leading = ", ".join(f"({n:.0f}, {h:.0f})" for n, h in self.tissues[:3])
-        return f"ZHL16State(tissues=[{leading}, …] mbar)"
-
-
-class ZHL16C(BaseDecoModel[ZHL16State]):
-    """Bühlmann ZHL-16C with Baker gradient factors.
-
-    Fresh instances start at surface equilibrium on air. The sample rate is
-    read from ``DiveConfig.current().planning.sample_rate_s`` at construction.
-
-    Args:
-        gradient: GF pair; defaults to ``Gradient(1.0, 1.0)`` (raw Bühlmann).
+    Sources: Bühlmann, *Tauchmedizin*; identical values are used by
+    Subsurface/OSTC.
     """
 
     NAME = "zhl16c"
 
-    __slots__ = ("gradient", "_compartments")
+    # fmt: off
+    N2_HALF_TIMES = (
+        5.0, 8.0, 12.5, 18.5, 27.0, 38.3, 54.3, 77.0,
+        109.0, 146.0, 187.0, 239.0, 305.0, 390.0, 498.0, 635.0,
+    )
+    N2_A = (
+        1.1696, 1.0000, 0.8618, 0.7562, 0.6200, 0.5043, 0.4410, 0.4000,
+        0.3750, 0.3500, 0.3295, 0.3065, 0.2835, 0.2610, 0.2480, 0.2327,
+    )
+    N2_B = (
+        0.5578, 0.6514, 0.7222, 0.7825, 0.8126, 0.8434, 0.8693, 0.8910,
+        0.9092, 0.9222, 0.9319, 0.9403, 0.9477, 0.9544, 0.9602, 0.9653,
+    )
+    HE_HALF_TIMES = (
+        1.88, 3.02, 4.72, 6.99, 10.21, 14.48, 20.53, 29.11,
+        41.20, 55.19, 70.69, 90.34, 115.29, 147.42, 188.24, 240.03,
+    )
+    HE_A = (
+        1.6189, 1.3830, 1.1919, 1.0458, 0.9220, 0.8205, 0.7305, 0.6502,
+        0.5950, 0.5545, 0.5333, 0.5189, 0.5181, 0.5176, 0.5172, 0.5119,
+    )
+    HE_B = (
+        0.4770, 0.5747, 0.6527, 0.7223, 0.7582, 0.7957, 0.8279, 0.8553,
+        0.8757, 0.8903, 0.8997, 0.9073, 0.9122, 0.9171, 0.9217, 0.9267,
+    )
+    # fmt: on
 
-    gradient: Gradient
-    _compartments: list[Compartment]
-
-    def __init__(self, gradient: Gradient | None = None):
-        super().__init__()
-        self.sample_rate_seconds = DiveConfig.current().planning.sample_rate_s
-        self.gradient = gradient if gradient is not None else Gradient(1.0, 1.0)
-        self._compartments = [
-            Compartment(
-                ht_n2=N2_HALF_TIMES[i],
-                ht_he=HE_HALF_TIMES[i],
-                a_n2=N2_A[i],
-                a_he=HE_A[i],
-                b_n2=N2_B[i],
-                b_he=HE_B[i],
-            )
-            for i in range(COMPARTMENT_COUNT)
-        ]
-
-    # ------------------------------------------------------------------
-    # BaseDecoModel contract
-    # ------------------------------------------------------------------
-
-    def _integrate_model(self, pressure: Pressure, gas: Gas, dt: timedelta) -> None:
-        for compartment in self._compartments:
-            compartment.integrate(pressure, gas, dt)
-
-    def _get_deco_state(self) -> ZHL16State:
-        return ZHL16State(tuple(c.tensions_mbar for c in self._compartments))
-
-    def get_ceiling(self, gradient_factor: float | None = None) -> Pressure:
-        """Minimum tolerated ambient pressure across all compartments.
-
-        A ceiling above surface pressure means decompression stops are
-        required. Defaults to GF-low (the conservative bound during the deep
-        phase); the ascent planner passes interpolated factors from
-        ``Gradient.factor()`` as the diver approaches the surface.
-        """
-        gf = gradient_factor if gradient_factor is not None else self.gradient.gf_low
-        return max(c.tolerated_ambient_pressure(gf) for c in self._compartments)
-
-    # ------------------------------------------------------------------
-    # State snapshot / restore (checkpointing, counterfactual queries)
-    # ------------------------------------------------------------------
-
-    def set_state(self, state: ZHL16State) -> None:
-        """Restore tissue tensions from a snapshot (exact, lossless)."""
-        for compartment, (ppn2, pphe) in zip(
-            self._compartments, state.tissues, strict=True
-        ):
-            compartment.set_tensions_mbar(ppn2, pphe)
-
-    def copy(self) -> "ZHL16C":
-        """Independent clone with the same gradient and tissue tensions —
-        for hypothetical ascents (TTS queries) without disturbing the run."""
-        clone = ZHL16C(gradient=self.gradient)
-        clone.sample_rate_seconds = self.sample_rate_seconds
-        clone.set_state(self._get_deco_state())
-        return clone
-
-    def __repr__(self) -> str:
-        return f"ZHL16C(gradient={self.gradient!r}, ceiling={self.get_ceiling()})"
+    __slots__ = ()

--- a/tests/test_buhlmann.py
+++ b/tests/test_buhlmann.py
@@ -22,17 +22,11 @@ from diveplan.models.buhlmann.common import (
     Compartment,
     Gradient,
 )
-from diveplan.models.buhlmann.zhl16 import (
-    COMPARTMENT_COUNT,
-    HE_HALF_TIMES,
-    N2_A,
-    N2_B,
-    N2_HALF_TIMES,
-    ZHL16C,
-    ZHL16State,
-)
+from diveplan.models.buhlmann.model import BuhlmannModel, BuhlmannState
+from diveplan.models.buhlmann.zhl16 import ZHL16C
 
 AIR = Gas.air()
+COMPARTMENT_COUNT = 16
 
 
 def surface_equilibrium_n2_mbar() -> float:
@@ -220,15 +214,21 @@ class TestCompartmentToleratedPressure:
 
 class TestZHL16CTables:
     def test_table_shapes(self):
-        for table in (N2_HALF_TIMES, N2_A, N2_B, HE_HALF_TIMES):
+        for table in (
+            ZHL16C.N2_HALF_TIMES,
+            ZHL16C.N2_A,
+            ZHL16C.N2_B,
+            ZHL16C.HE_HALF_TIMES,
+        ):
             assert len(table) == COMPARTMENT_COUNT
+        assert ZHL16C().compartment_count == COMPARTMENT_COUNT
 
     def test_half_times_monotonic(self):
-        assert list(N2_HALF_TIMES) == sorted(N2_HALF_TIMES)
-        assert list(HE_HALF_TIMES) == sorted(HE_HALF_TIMES)
+        assert list(ZHL16C.N2_HALF_TIMES) == sorted(ZHL16C.N2_HALF_TIMES)
+        assert list(ZHL16C.HE_HALF_TIMES) == sorted(ZHL16C.HE_HALF_TIMES)
 
     def test_b_coefficients_bounded(self):
-        assert all(0 < b < 1 for b in N2_B)
+        assert all(0 < b < 1 for b in ZHL16C.N2_B)
 
 
 class TestZHL16CModel:
@@ -271,7 +271,7 @@ class TestZHL16CModel:
         state = model.integrate_segment(
             DiveSegment(Pressure.from_depth_m(20), Pressure.from_depth_m(20), 5, AIR)
         )
-        assert isinstance(state, ZHL16State)
+        assert isinstance(state, BuhlmannState)
         assert len(state.tissues) == COMPARTMENT_COUNT
 
     def test_fast_compartment_leads_on_short_exposure(self):
@@ -309,9 +309,71 @@ class TestZHL16CModel:
         with pytest.raises(AttributeError, match="immutable"):
             state.tissues = ()
 
-    def test_state_length_validation(self):
-        with pytest.raises(ValueError, match="16 tissue"):
-            ZHL16State(((750.0, 0.0),))
+    def test_empty_state_rejected(self):
+        with pytest.raises(ValueError, match="at least one"):
+            BuhlmannState(())
+
+    def test_set_state_length_mismatch_rejected(self):
+        with pytest.raises(ValueError, match="1 compartments.*16"):
+            ZHL16C().set_state(BuhlmannState(((750.0, 0.0),)))
+
+
+# ------------------------------------------------------------------
+# Bühlmann family (engine/table separation)
+# ------------------------------------------------------------------
+
+
+class MiniBuhlmann(BuhlmannModel):
+    """Two-compartment toy variant — proves models are table-only subclasses."""
+
+    NAME = "mini"
+    N2_HALF_TIMES = (5.0, 635.0)
+    N2_A = (1.1696, 0.2327)
+    N2_B = (0.5578, 0.9653)
+    HE_HALF_TIMES = (1.88, 240.03)
+    HE_A = (1.6189, 0.5119)
+    HE_B = (0.4770, 0.9267)
+
+    __slots__ = ()
+
+
+class TestBuhlmannFamily:
+    def test_engine_is_abstract(self):
+        with pytest.raises(TypeError, match="abstract engine"):
+            BuhlmannModel()
+
+    def test_variant_is_table_only(self):
+        model = MiniBuhlmann()
+        assert model.compartment_count == 2
+        state = model.integrate_segment(
+            DiveSegment(Pressure.from_depth_m(30), Pressure.from_depth_m(30), 10, AIR)
+        )
+        assert len(state.tissues) == 2
+        assert model.get_ceiling() < Pressure.surface()
+
+    def test_mismatched_tables_rejected_at_class_definition(self):
+        with pytest.raises(TypeError, match="mismatched lengths"):
+
+            class Broken(BuhlmannModel):
+                NAME = "broken"
+                N2_HALF_TIMES = (5.0, 8.0)
+                N2_A = (1.1696,)  # wrong length
+                N2_B = (0.5578, 0.6514)
+                HE_HALF_TIMES = (1.88, 3.02)
+                HE_A = (1.6189, 1.3830)
+                HE_B = (0.4770, 0.5747)
+
+    def test_partial_tables_rejected_at_class_definition(self):
+        with pytest.raises(TypeError, match="missing"):
+
+            class Incomplete(BuhlmannModel):
+                NAME = "incomplete"
+                N2_HALF_TIMES = (5.0,)
+
+    def test_copy_preserves_subclass(self):
+        clone = MiniBuhlmann(gradient=Gradient(0.4, 0.9)).copy()
+        assert type(clone) is MiniBuhlmann
+        assert clone.gradient == Gradient(0.4, 0.9)
 
 
 class TestZHL16CRegistry:

--- a/tests/test_buhlmann.py
+++ b/tests/test_buhlmann.py
@@ -1,0 +1,325 @@
+"""
+Tests for diveplan.models.buhlmann (Gradient, Compartment, ZHL16C).
+
+Physics checks are property-based against the Haldane/Bühlmann equations
+rather than external dive-table vectors: half-time behaviour is exact,
+GF interpolation endpoints are exact, and deco/no-deco outcomes use dives
+far on either side of published ZHL-16C no-stop limits so the assertions
+are robust to small implementation differences (integer surface pressure,
+water-vapor constant).
+"""
+
+from datetime import timedelta
+
+import pytest
+
+from diveplan.core.config import DiveConfig
+from diveplan.core.dive_segment import DiveSegment
+from diveplan.core.gas import Gas
+from diveplan.core.pressure import Pressure
+from diveplan.models.buhlmann.common import (
+    WATER_VAPOR_PRESSURE_MBAR,
+    Compartment,
+    Gradient,
+)
+from diveplan.models.buhlmann.zhl16 import (
+    COMPARTMENT_COUNT,
+    HE_HALF_TIMES,
+    N2_A,
+    N2_B,
+    N2_HALF_TIMES,
+    ZHL16C,
+    ZHL16State,
+)
+
+AIR = Gas.air()
+
+
+def surface_equilibrium_n2_mbar() -> float:
+    return (Pressure.surface().mbar - WATER_VAPOR_PRESSURE_MBAR) * 0.79
+
+
+def make_compartment(**overrides) -> Compartment:
+    """Compartment 1b of ZHL-16C unless overridden."""
+    kwargs = dict(
+        ht_n2=5.0, ht_he=1.88, a_n2=1.1696, a_he=1.6189, b_n2=0.5578, b_he=0.4770
+    )
+    kwargs.update(overrides)
+    return Compartment(**kwargs)
+
+
+# ------------------------------------------------------------------
+# Gradient
+# ------------------------------------------------------------------
+
+
+class TestGradient:
+    def test_validation(self):
+        with pytest.raises(ValueError):
+            Gradient(0, 0.85)
+        with pytest.raises(ValueError):
+            Gradient(0.3, -1)
+
+    def test_gf_high_at_surface(self):
+        gf = Gradient(0.3, 0.85)
+        first_stop = Pressure.from_depth_m(9)
+        assert gf.factor(Pressure.surface(), first_stop) == 0.85
+
+    def test_gf_low_at_and_below_first_stop(self):
+        gf = Gradient(0.3, 0.85)
+        first_stop = Pressure.from_depth_m(9)
+        assert gf.factor(first_stop, first_stop) == 0.3
+        assert gf.factor(Pressure.from_depth_m(30), first_stop) == 0.3
+
+    def test_linear_midpoint(self):
+        gf = Gradient(0.3, 0.85)
+        surface = Pressure.surface()
+        first_stop = Pressure.from_depth_m(10)
+        midpoint = Pressure(round((surface.mbar + first_stop.mbar) / 2))
+        assert gf.factor(midpoint, first_stop) == pytest.approx(
+            (0.3 + 0.85) / 2, abs=1e-3
+        )
+
+    def test_continuous_near_surface(self):
+        # No jump between the surface value and a point just below it.
+        gf = Gradient(0.3, 0.85)
+        first_stop = Pressure.from_depth_m(9)
+        just_below = Pressure(Pressure.surface().mbar + 10)  # ~10 cm deep
+        assert gf.factor(just_below, first_stop) == pytest.approx(0.85, abs=0.01)
+
+    def test_flat_pair(self):
+        gf = Gradient(0.8, 0.8)
+        assert gf.factor(Pressure.from_depth_m(5), Pressure.from_depth_m(9)) == 0.8
+
+    def test_first_stop_at_surface_returns_gf_high(self):
+        gf = Gradient(0.3, 0.85)
+        below = Pressure.from_depth_m(1)
+        assert gf.factor(below, Pressure.surface()) == 0.3  # >= first stop
+        assert gf.factor(Pressure.surface(), Pressure.surface()) == 0.3
+
+    def test_str(self):
+        assert str(Gradient(0.3, 0.85)) == "GF 30/85"
+
+
+# ------------------------------------------------------------------
+# Compartment
+# ------------------------------------------------------------------
+
+
+class TestCompartmentState:
+    def test_default_surface_equilibrium(self):
+        c = make_compartment()
+        assert c.tensions_mbar[0] == pytest.approx(surface_equilibrium_n2_mbar())
+        assert c.tensions_mbar[1] == 0.0
+
+    def test_explicit_initial_tensions(self):
+        c = make_compartment(ppn2=Pressure(2000), pphe=Pressure(500))
+        assert c.tensions_mbar == (2000.0, 500.0)
+
+    def test_validation(self):
+        with pytest.raises(ValueError):
+            make_compartment(ht_n2=0)
+        with pytest.raises(ValueError):
+            make_compartment(b_n2=0)
+        with pytest.raises(ValueError):
+            make_compartment().set_tensions_mbar(-1, 0)
+
+    def test_copy_is_independent(self):
+        c = make_compartment()
+        clone = c.copy()
+        assert clone == c
+        clone.integrate(Pressure.from_depth_m(30), AIR, timedelta(minutes=10))
+        assert clone != c
+
+
+class TestCompartmentIntegration:
+    def test_half_time_is_exact(self):
+        # After exactly one half-time at constant conditions, the tension
+        # closes exactly half the gap to the alveolar pressure.
+        c = make_compartment()
+        start = c.tensions_mbar[0]
+        depth = Pressure.from_depth_m(30)
+        alveolar_n2 = (depth.mbar - WATER_VAPOR_PRESSURE_MBAR) * AIR.fn2
+
+        c.integrate(depth, AIR, timedelta(minutes=5.0))  # ht_n2 = 5.0
+        expected = start + (alveolar_n2 - start) * 0.5
+        assert c.tensions_mbar[0] == pytest.approx(expected, rel=1e-9)
+
+    def test_integration_is_composable(self):
+        # Two 5-minute steps must equal one 10-minute step (exponential decay
+        # composes) — the property the segment integrator relies on.
+        depth = Pressure.from_depth_m(40)
+        one_step = make_compartment()
+        two_steps = make_compartment()
+        one_step.integrate(depth, AIR, timedelta(minutes=10))
+        two_steps.integrate(depth, AIR, timedelta(minutes=5))
+        two_steps.integrate(depth, AIR, timedelta(minutes=5))
+        assert two_steps.tensions_mbar[0] == pytest.approx(
+            one_step.tensions_mbar[0], rel=1e-9
+        )
+
+    def test_saturation_approaches_alveolar(self):
+        c = make_compartment()
+        depth = Pressure.from_depth_m(30)
+        alveolar_n2 = (depth.mbar - WATER_VAPOR_PRESSURE_MBAR) * AIR.fn2
+        c.integrate(depth, AIR, timedelta(minutes=5.0 * 20))  # 20 half-times
+        assert c.tensions_mbar[0] == pytest.approx(alveolar_n2, rel=1e-5)
+
+    def test_helium_loads_on_trimix(self):
+        c = make_compartment()
+        c.integrate(
+            Pressure.from_depth_m(50), Gas.trimix(0.18, 0.45), timedelta(minutes=20)
+        )
+        assert c.tensions_mbar[1] > 1000  # substantial He uptake
+
+    def test_slow_tissue_not_frozen_by_small_steps(self):
+        # Regression guard for integer-quantization starvation: 1-second steps
+        # on the slowest compartment must still accumulate tension.
+        c = make_compartment(ht_n2=635.0, ht_he=240.03)
+        start = c.tensions_mbar[0]
+        depth = Pressure.from_depth_m(40)
+        for _ in range(600):  # 10 minutes of 1 s steps
+            c.integrate(depth, AIR, timedelta(seconds=1))
+        assert c.tensions_mbar[0] > start + 10  # moved by whole mbars
+
+
+class TestCompartmentToleratedPressure:
+    def test_gf1_reduces_to_buhlmann(self):
+        # Baker formula at GF=1 must equal the classic (P_t - a) * b.
+        c = make_compartment(ppn2=Pressure(4000), pphe=Pressure(0))
+        expected = (4000 - 1.1696 * 1000) * 0.5578
+        assert c.tolerated_ambient_pressure(1.0).mbar == pytest.approx(
+            expected, abs=1.0
+        )
+
+    def test_lower_gf_is_more_conservative(self):
+        # Lower GF allows less supersaturation → deeper ceiling (higher
+        # tolerated ambient pressure). At GF→0 the ceiling approaches the
+        # tissue tension itself.
+        c = make_compartment(ppn2=Pressure(4000))
+        assert c.tolerated_ambient_pressure(0.3) > c.tolerated_ambient_pressure(1.0)
+        assert c.tolerated_ambient_pressure(0.001).mbar == pytest.approx(4000, abs=5)
+
+    def test_surface_equilibrium_needs_no_deco(self):
+        c = make_compartment()
+        assert c.tolerated_ambient_pressure(1.0) < Pressure.surface()
+
+    def test_desaturated_compartment_clamps_to_zero(self):
+        c = make_compartment(ppn2=Pressure(0), pphe=Pressure(0))
+        assert c.tolerated_ambient_pressure(1.0) == Pressure(0)
+
+    def test_gf_validation(self):
+        with pytest.raises(ValueError):
+            make_compartment().tolerated_ambient_pressure(0)
+
+
+# ------------------------------------------------------------------
+# ZHL16C
+# ------------------------------------------------------------------
+
+
+class TestZHL16CTables:
+    def test_table_shapes(self):
+        for table in (N2_HALF_TIMES, N2_A, N2_B, HE_HALF_TIMES):
+            assert len(table) == COMPARTMENT_COUNT
+
+    def test_half_times_monotonic(self):
+        assert list(N2_HALF_TIMES) == sorted(N2_HALF_TIMES)
+        assert list(HE_HALF_TIMES) == sorted(HE_HALF_TIMES)
+
+    def test_b_coefficients_bounded(self):
+        assert all(0 < b < 1 for b in N2_B)
+
+
+class TestZHL16CModel:
+    def test_fresh_model_has_no_ceiling(self):
+        model = ZHL16C()
+        assert model.get_ceiling() < Pressure.surface()
+
+    def test_sample_rate_from_config(self):
+        DiveConfig.current().planning.sample_rate_s = 4
+        assert ZHL16C().sample_rate_seconds == 4
+
+    def test_no_deco_short_shallow_dive(self):
+        # 12 m for 10 min on air is far inside any no-stop limit.
+        model = ZHL16C()
+        segment = DiveSegment(
+            Pressure.from_depth_m(12), Pressure.from_depth_m(12), 10, AIR
+        )
+        model.integrate_segment(segment)
+        assert model.get_ceiling() <= Pressure.surface()
+
+    def test_deco_required_after_long_deep_dive(self):
+        # 40 m for 30 min on air is far beyond the no-stop limit (~9 min).
+        model = ZHL16C()
+        segment = DiveSegment(
+            Pressure.from_depth_m(40), Pressure.from_depth_m(40), 30, AIR
+        )
+        model.integrate_segment(segment)
+        assert model.get_ceiling() > Pressure.surface()
+
+    def test_lower_gf_raises_ceiling(self):
+        bottom = DiveSegment(
+            Pressure.from_depth_m(40), Pressure.from_depth_m(40), 30, AIR
+        )
+        model = ZHL16C()
+        model.integrate_segment(bottom)
+        assert model.get_ceiling(0.3) > model.get_ceiling(1.0)
+
+    def test_integrate_segment_returns_state(self):
+        model = ZHL16C()
+        state = model.integrate_segment(
+            DiveSegment(Pressure.from_depth_m(20), Pressure.from_depth_m(20), 5, AIR)
+        )
+        assert isinstance(state, ZHL16State)
+        assert len(state.tissues) == COMPARTMENT_COUNT
+
+    def test_fast_compartment_leads_on_short_exposure(self):
+        model = ZHL16C()
+        state = model.integrate_segment(
+            DiveSegment(Pressure.from_depth_m(30), Pressure.from_depth_m(30), 5, AIR)
+        )
+        assert state.tissues[0][0] > state.tissues[-1][0]
+
+    def test_state_snapshot_restore_round_trip(self):
+        model = ZHL16C()
+        state = model.integrate_segment(
+            DiveSegment(Pressure.from_depth_m(30), Pressure.from_depth_m(30), 15, AIR)
+        )
+        restored = ZHL16C()
+        restored.set_state(state)
+        assert restored._get_deco_state() == state
+        assert restored.get_ceiling() == model.get_ceiling()
+
+    def test_copy_supports_counterfactuals(self):
+        model = ZHL16C(gradient=Gradient(0.3, 0.85))
+        model.integrate_segment(
+            DiveSegment(Pressure.from_depth_m(40), Pressure.from_depth_m(40), 20, AIR)
+        )
+        before = model._get_deco_state()
+        clone = model.copy()
+        clone.integrate_segment(  # hypothetical extra bottom time
+            DiveSegment(Pressure.from_depth_m(40), Pressure.from_depth_m(40), 20, AIR)
+        )
+        assert model._get_deco_state() == before  # original undisturbed
+        assert clone._get_deco_state() != before
+
+    def test_state_immutability(self):
+        state = ZHL16C()._get_deco_state()
+        with pytest.raises(AttributeError, match="immutable"):
+            state.tissues = ()
+
+    def test_state_length_validation(self):
+        with pytest.raises(ValueError, match="16 tissue"):
+            ZHL16State(((750.0, 0.0),))
+
+
+class TestZHL16CRegistry:
+    def test_discoverable_via_entry_point(self):
+        from diveplan.registry import PluginRegistry
+
+        fresh = PluginRegistry()  # bypass the module singleton's cache
+        assert fresh.model("zhl16c") is ZHL16C
+
+    def test_default_model_config_matches(self):
+        assert DiveConfig.current().planning.default_model == "zhl16c"


### PR DESCRIPTION
## Summary

Stacked on #2 (merge that first; this PR targets its branch and can be retargeted to main after).

**Bühlmann helpers rewritten** ([common.py](../blob/feat/buhlmann-zhl16c/src/diveplan/models/buhlmann/common.py)) — the previous version had never been executed and carried: inverted GF interpolation (GF-low at surface instead of at depth) that was also discontinuous near the surface; O2 partial pressure integrated into the N2 tissue tension; He tissues initialized at full surface pressure; no alveolar water-vapor correction; and Pressure/float arithmetic that raises TypeError. All replaced with tested Haldane/Baker physics.

**Design note:** tissue tensions are float mbar *internally* — at a 1 s sample rate a 635 min compartment moves ~0.06 mbar/step, so integer-mbar quantization would freeze it forever. `Pressure` stays the boundary type everywhere else. There's a regression test for exactly this.

**ZHL-16C implemented** (`zhl16.py`): 16 compartments (1b variant, published C tables), `ZHL16State` frozen snapshots with `set_state()`/`copy()` for checkpointing and TTS-style counterfactual queries, `get_ceiling(gf)`, and the `zhl16c` entry point re-enabled (registry discovery is tested; config `default_model` already pointed here).

## Testing

- 363 tests pass (38 new). Physics tests are property-based and exact where the math is exact: one-half-time closes exactly half the gap, integration composes (5+5 min ≡ 10 min), Baker's GF formula reduces to Bühlmann `(P_t − a)·b` at GF = 1, GF endpoints/continuity, deco vs. no-deco outcomes far on either side of published no-stop limits.
- `mypy src` strict is now **fully clean** (the 3 pre-existing errors lived in the old common.py); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)