### PR TITLE
Result layer (DiveResult, checkpoints, tts) + ascent planner

### DIFF
--- a/.claude/codebase-index.md
+++ b/.claude/codebase-index.md
@@ -1,6 +1,6 @@
 # diveplan codebase index
 
-Auto-generated API map (regenerate: `uv run python .claude/generate-index.py`). Generated 2026-07-05.
+Auto-generated API map (regenerate: `uv run python .claude/generate-index.py`). Generated 2026-07-06.
 
 Read this instead of source files when you only need signatures/structure. Read the actual source before *editing* anything listed here.
 
@@ -13,7 +13,7 @@ diveplan — dive planning and decompression calculation library.
   - @property `planning(self) -> _DivePlanningConfig`
   dunders: `__repr__, __str__`
 - const `diveconfig = _ConfigProxy()`
-`__all__ = ['Pressure', 'Gas', 'DiveSegment', 'SegmentKind', 'DiveConfig', 'diveconfig']`
+`__all__ = ['Pressure', 'Gas', 'DiveSegment', 'SegmentKind', 'DiveConfig', 'diveconfig', 'DiveProfile', 'DiveResult', 'GasPlan', 'plan_ascent']`
 
 ## `src/diveplan/core/__init__.py`
 Core value objects and configuration for diveplan.
@@ -142,7 +142,7 @@ core/pressure.py — Pressure value type.
 (empty stub)
 
 ## `src/diveplan/dive/dive_profile.py`
-`__all__ = ('DiveProfile', 'ProfileValidationError', 'ProfileContinuityError', 'ProfileSimplicityError', 'ProfileStartEndError', 'ProfileDepthContinuityError', 'ProfileGasContinuityError', 'ProfileEmptyError', 'ProfileTooShortError', 'ProfileBuilderPolicy')`
+`__all__ = ('DiveProfile', 'ProfileSample', 'ProfileValidationError', 'ProfileContinuityError', 'ProfileSimplicityError', 'ProfileStartEndError', 'ProfileDepthContinuityError', 'ProfileGasContinuityError', 'ProfileEmptyError', 'ProfileTooShortError', 'ProfileBuilderPolicy')`
 ### class `ProfileValidationError` (ValueError) — Base descriptor for a dive profile validation problem.
   - `__init__(self, message: str, *, segment_index: Optional[int] = None, segments: tuple[DiveSegment, ...] = ())`
   attrs: `fixable: bool = False`
@@ -170,6 +170,8 @@ core/pressure.py — Pressure value type.
 ### class `ProfileBuilderPolicy` (Enum) — Policies for handling validation during dive profile construction.
   attrs: `RAISE_BAD_PROFILE = auto(); ALLOW_BAD_PROFILE = auto(); AUTOFIX_BAD_PROFILE = auto()`
 - `_as_timedelta(value: timedelta | float) -> timedelta`  — Coerce a time argument: timedelta as-is, bare numbers as minutes
+### class `ProfileSample` (NamedTuple) — One integration step on the profile's global timeline.
+  attrs: `time: timedelta; dt: timedelta; pressure: Pressure; gas: Gas; segment_index: int`
 ### class `DiveProfile` — A dive profile consisting of a sequence of dive segments.
   `__slots__ = ('_segments', '_builder_policy')`
   - `__init__(self, builder_policy: ProfileBuilderPolicy = ProfileBuilderPolicy.RAISE_BAD_PROFILE)`  — Initialize a new DiveProfile.
@@ -185,7 +187,9 @@ core/pressure.py — Pressure value type.
   - `segment_at(self, t: timedelta | float) -> DiveSegment`  — The segment active at runtime `t` (minutes or timedelta).
   - `pressure_at(self, t: timedelta | float) -> Pressure`  — Ambient pressure at runtime `t` (minutes or timedelta), interpolated
   - `gas_at(self, t: timedelta | float) -> Gas`  — Breathing gas at runtime `t` (minutes or timedelta).
+  - `iter_samples(self, interval: timedelta | float) -> Iterator[ProfileSample]`  — Yield integration steps over the whole profile timeline.
   - @staticmethod `_is_gas_switch_seam(a: DiveSegment, b: DiveSegment) -> bool`  — A seam is a legitimate gas switch if either side is a GAS_SWITCH segment.
+  - @staticmethod `_is_mergeable(a: DiveSegment, b: DiveSegment) -> bool`  — Adjacent segments are redundant only if fully continuous AND of the
   - `_seam_error(self, a: DiveSegment, b: DiveSegment, index: int) -> Optional[ProfileValidationError]`  — Return the most fundamental continuity error at the seam (a → b), or None.
   - `_raise_on_seam(self, a: DiveSegment, b: DiveSegment, index: int) -> None`  — Under RAISE policy, raise the seam error (a → b) if there is one.
   - `_check_insertion(self, index: int, segment: DiveSegment) -> None`  — Under RAISE policy, validate the seam(s) a new segment at `index` would create.
@@ -230,6 +234,24 @@ core/pressure.py — Pressure value type.
 ## `src/diveplan/dive/dive_report.py`
 (empty stub)
 
+## `src/diveplan/dive/dive_result.py`
+Result layer: a deco model run over a profile, queryable by time.
+`__all__ = ['DiveResult']`
+### class `DiveResult[StateT: DecoState]` — A deco model's run over a profile: checkpoints + time queries.
+  `__slots__ = ('_profile', '_model', '_checkpoints')`
+  - `__init__(self, profile: DiveProfile, model: BaseDecoModel[StateT], checkpoints: tuple[StateT, ...])`
+  - @classmethod `run(cls, profile: DiveProfile, model: BaseDecoModel[StateT]) -> 'DiveResult[StateT]'`  — Integrate `model` over `profile` and capture boundary checkpoints.
+  - @property `profile(self) -> DiveProfile`  — The dive profile this result was computed from (own copy).
+  - @property `checkpoints(self) -> tuple[StateT, ...]`  — Model states at segment boundaries; ``[0]`` is the pre-dive state,
+  - @property `final_state(self) -> StateT`  — Model state at the end of the profile.
+  - `model_at(self, t: timedelta | float) -> BaseDecoModel[StateT]`  — Independent model instance positioned at runtime `t`.
+  - `state_at(self, t: timedelta | float) -> StateT`  — Model state at runtime `t` (minutes or timedelta).
+  - `ceiling_at(self, t: timedelta | float) -> Pressure`  — Deco ceiling at runtime `t`.
+  - `tissue_series(self, interval: timedelta | float) -> Iterator[tuple[timedelta, StateT]]`  — Yield (time, state) at each sample step — for tissue plots.
+  - `tts(self, t: timedelta | float, gas_plan: GasPlan | None = None) -> timedelta`  — Time-to-surface at runtime `t`: the duration of an ascent planned
+  - `_unique_gases(self) -> list[Gas]`
+  dunders: `__repr__`
+
 ## `src/diveplan/dive/formatters/__init__.py`
 (empty stub)
 
@@ -245,9 +267,13 @@ Decompression model base classes.
   `__slots__ = ('sample_rate_seconds',)`
   - @abstract `__init__(self) -> None`  — Initialize the decompression model.
   - `integrate_segment(self, segment: DiveSegment) -> StateT`  — Integrate a dive segment into the model and return the state after it.
+  - `get_state(self) -> StateT`  — Snapshot the current model state (public accessor).
+  - `integrate(self, pressure: Pressure, gas: Gas, dt: timedelta) -> None`  — Advance the model by a single step at the given pressure and gas.
   - @abstract `_integrate_model(self, pressure: Pressure, gas: Gas, dt: timedelta) -> None`  — Advance the model by dt at the given ambient pressure and gas.
   - @abstract `_get_deco_state(self) -> StateT`  — Snapshot the current model state.
   - @abstract `get_ceiling(self) -> Pressure`  — Return the current ceiling depth.
+  - @abstract `set_state(self, state: StateT) -> None`  — Restore the model to a previously snapshotted state (lossless).
+  - @abstract `copy(self) -> Self`  — Independent clone with identical configuration and current state.
   attrs: `NAME: ClassVar[str]`
 
 ## `src/diveplan/models/buhlmann/__init__.py`
@@ -346,13 +372,27 @@ VPM-B decompression model (Varying Permeability Model, revision B).
   dunders: `__repr__`
 
 ## `src/diveplan/planning/__init__.py`
-(empty stub)
+Ascent planning: deco schedules and gas selection.
+`__all__ = ['plan_ascent', 'GasPlan', 'AscentNotConvergingError']`
 
 ## `src/diveplan/planning/ascent_plan.py`
-(empty stub)
+Ascent planner: compute the decompression schedule from a model state.
+`__all__ = ['plan_ascent', 'AscentNotConvergingError']`
+### class `AscentNotConvergingError` (RuntimeError) — The stop loop failed to clear the next target within the iteration cap.
+- `_ceiling(model: BaseDecoModel[Any], target: Pressure, first_stop: Optional[Pressure]) -> Pressure`  — Model ceiling for an ascent-to-`target` test.
+- `_next_targets(current: Pressure) -> list[Pressure]`  — Candidate ascent targets from shallowest to deepest: the surface, then
+- `plan_ascent(model: BaseDecoModel[Any], start_pressure: Pressure, gas: Gas, gas_plan: Optional[GasPlan] = None) -> list[DiveSegment]`  — Plan the decompression ascent from the given position and model state.
 
 ## `src/diveplan/planning/gas_plan.py`
-(empty stub)
+Gas plan: the set of gases carried on a dive, and which to breathe when.
+`__all__ = ['GasPlan']`
+### class `GasPlan` — An ordered collection of carried gases with depth-based selection.
+  `__slots__ = ('_gases',)`
+  - `__init__(self, gases: Iterable[Gas])`
+  - @property `gases(self) -> tuple[Gas, ...]`  — The carried gases (duplicates removed, insertion order).
+  - @staticmethod `is_breathable(gas: Gas, pressure: Pressure) -> bool`  — Whether `gas` is within the configured deco ppO2 window here.
+  - `best_gas_at(self, pressure: Pressure) -> Optional[Gas]`  — Richest breathable gas at `pressure`, or None if none qualifies.
+  dunders: `__repr__`
 
 ## `src/diveplan/registry.py`
 ### class `PluginNotFoundError` (KeyError)
@@ -384,7 +424,9 @@ VPM-B decompression model (Varying Permeability Model, revision B).
 - `test_buhlmann.py` (44 tests) — TestGradient, TestCompartmentState, TestCompartmentIntegration, TestCompartmentToleratedPressure, TestZHL16CTables, TestZHL16CModel, MiniBuhlmann, TestBuhlmannFamily, TestZHL16CRegistry
 - `test_config.py` (45 tests) — TestSubConfigBase, TestPhysicsConfig, TestGasConfig, TestDivePlanningConfig, TestDiveConfigStructure, TestGlobalDefault, TestContextManager, TestDefaultConfigLoading, TestSerialization
 - `test_dive_profile.py` (74 tests) — TestDiveProfileBuilder, TestDiveProfileValidation, TestDiveProfileFixes, TestDiveProfileTimeline, TestDiveProfileFluentBuilders, TestDiveProfileSerialization
+- `test_dive_result.py` (20 tests) — TestIterSamples, TestDiveResultRun, TestDiveResultQueries
 - `test_dive_segment.py` (59 tests) — TestDiveSegmentConstruction, TestDiveSegmentProperties, TestDiveSegmentInterpolation, TestDiveSegmentSplitting, TestDiveSegmentMerging, TestDiveSegmentContinuity, TestDiveSegmentIteration, TestDiveSegmentMagicMethods, TestDiveSegmentImmutability, TestDiveSegmentSerialization
 - `test_gas.py` (61 tests) — TestRawConstruction, TestNamedConstructors, TestFromName, TestPartialPressures, TestMod, TestEnd, TestBestMix, TestEqualityAndHash, TestStringRepresentation
+- `test_planning.py` (15 tests) — TestGasPlan, TestPlanAscentNoDeco, TestPlanAscentDeco
 - `test_pressure.py` (70 tests) — TestConstruction, TestProperties, TestAltConstructorsAndProperties, TestStringParsing, TestImmutability, TestAddition, TestSubtraction, TestMultiplication, TestDivision, TestOrdering, TestHashing, TestDisplay
 - `test_vpm.py` (23 tests) — TestBubbleMechanics, TestVpmBModel, TestVpmBRegistry

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,11 +35,12 @@ Line endings are LF, enforced via `.gitattributes`.
 Layering (imports flow strictly downward; `core/` never imports from upper layers):
 
 ```
-core/      Pressure, Gas, DiveSegment, DiveConfig — value objects + config
-dive/      DiveProfile (builder/validation/timeline), reports, formatters
-models/    deco models (BaseDecoModel, DecoState, Bühlmann helpers)
-planning/  ascent planner, gas plan (stubs — in progress)
-registry.py  entry-point plugin discovery for deco models
+core/          Pressure, Gas, DiveSegment, DiveConfig — value objects + config
+dive/dive_profile.py  DiveProfile (builder/validation/timeline/iter_samples) — core only
+models/        deco models (BaseDecoModel[StateT], Bühlmann family, VPM-B)
+planning/      plan_ascent + GasPlan — consumes models
+dive/dive_result.py   DiveResult — top of the stack (profile + models + planning)
+registry.py    entry-point plugin discovery for deco models
 ```
 
 ### Pressure is ground truth
@@ -61,7 +62,9 @@ Tests: `tests/conftest.py` has an autouse fixture pinning a fresh factory-defaul
 
 ### DiveProfile: plan is input, results are output
 
-A profile is pure geometry (list of segments). Do **not** hang model results (tissue states, ceilings, TTS) on segments or the profile — results belong in a separate result layer so one profile can be run under multiple models/GFs and compared. This is a deliberate, agreed design constraint.
+A profile is pure geometry (list of segments). Do **not** hang model results (tissue states, ceilings, TTS) on segments or the profile — results live in `DiveResult` (`dive/dive_result.py`) so one profile can be run under multiple models/GFs and compared. This is a deliberate, agreed design constraint.
+
+`DiveResult.run(profile, model)` copies the model, integrates, and stores **state checkpoints at segment boundaries only** (O(segments) memory for batch). Time queries (`state_at`, `ceiling_at`, `model_at`, `tts(t)`) re-integrate at most one partial segment from the nearest checkpoint — exact, because Haldane integration composes. `tissue_series(dt)` reproduces checkpoints exactly only when sampled at the model's own rate (rectangle rule). `DiveProfile.iter_samples(interval)` is the single sampling authority: steps never cross segment boundaries, the last step of a segment is shortened, zero-duration switches yield no step.
 
 Key mechanics spread across `dive/dive_profile.py`:
 
@@ -73,13 +76,19 @@ Key mechanics spread across `dive/dive_profile.py`:
 
 ### Deco models and plugins
 
-`BaseDecoModel[StateT: DecoState]` (PEP 695 generics): each model defines its own immutable `DecoState` subclass and returns typed state, not dicts. State snapshots are the currency for future checkpointing and counterfactual queries (TTS at time t) — keep them cheap to copy.
+`BaseDecoModel[StateT: DecoState]` (PEP 695 generics): each model defines its own immutable `DecoState` subclass and returns typed state, not dicts. `set_state()`/`copy()`/`get_state()` are abstract contract — the result layer's checkpointing and TTS counterfactuals depend on them being lossless and cheap.
+
+Model families: `BuhlmannModel` (models/buhlmann/model.py) is the whole Bühlmann algorithm; a variant like `ZHL16C` is only `NAME` + six coefficient tables, validated at class-definition time. VPM-B (models/vpm/) is a bubble model: same ZHL-16 half-times for loading, ceiling from nuclei mechanics; constants verified against Subsurface deco.cpp (bar/µm units). Tissue tensions are **float mbar internally** in both families — integer quantization would freeze slow compartments at 1 s steps; `Pressure` is the boundary type only.
+
+### Ascent planner
+
+`plan_ascent(model, start_pressure, gas, gas_plan)` (planning/ascent_plan.py) is a pure function: clones the model, returns continuous segments to the surface (deco ascents merged, stop chunks merged, gas switches at stops). GF models get the gradient interpolated at each target depth, anchored at the first (deepest) stop of the ascent; non-GF models are asked for their plain ceiling. Known limits: gas switches only at stops; VPM-B's Critical Volume Algorithm and Boyle compensation are **not applied yet** — its schedules use conservative pre-CVA gradients (`CRIT_VOLUME_LAMBDA_BAR_MIN` is exported for when CVA lands here).
 
 Plugin discovery: entry-point group **`diveplan.deco_models`** (single source of truth: `_ENTRY_POINT_GROUP` in `registry.py`). The registry eagerly loads *every* entry point in the group on first access, so never register an entry point in `pyproject.toml` before its module exists — one dangling reference breaks all model lookups. The `zhl16c` and formatter entry points are commented out in `pyproject.toml` until their modules land; `DiveConfig.planning.default_model` defaults to `"zhl16c"`, so uncomment the entry point in the same PR that adds `zhl16.py`. `registry.register_model()` is the manual escape hatch for tests.
 
 ### Known state / gotchas
 
-- `models/buhlmann/common.py` is in-progress and has known issues: `Gradient.factor` is inverted vs. standard gradient-factor convention (GF-low belongs at the deepest stop, GF-high at surface) and interpolates on absolute-pressure ratio; it also fails strict mypy. Fix before building the ascent planner on it.
-- `planning/` and `dive/dive_report.py` are empty stubs.
+- `dive/dive_report.py` and `dive/formatters/` are empty stubs (report layer not started).
+- VPM-B CVA + Boyle compensation pending in the planner (see above).
 - `diveplan_roadmap.md` predates implementation and drifts from the code in places (e.g. `DiveStep`/`AbstractDecoModel` naming — the code's `DiveSegment`/`BaseDecoModel` won); trust the code.
-- `__init__.py` re-exports core types and a `diveconfig` proxy; planning/dive/report symbols get re-exported there as layers land.
+- `__init__.py` re-exports core types, `DiveProfile`, `DiveResult`, `GasPlan`, `plan_ascent`, and a `diveconfig` proxy.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ pip install -e ".[dev]"
 
 ## Quickstart
 
+A complete end-to-end walkthrough (config → gases → profile → models →
+result queries → ascent plan → serialization) lives in
+[`examples/complete_dive_plan.py`](examples/complete_dive_plan.py):
+
+```bash
+uv run python examples/complete_dive_plan.py
+```
+
 ```python
 from diveplan import Pressure, Gas, DiveConfig
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,12 @@ Early development. The **core layer is implemented and tested**:
 | `Gas` — O2/He/N2 mixes, MOD/END/best-mix | ✅ |
 | `DiveSegment` / `SegmentKind` — one leg of a profile | ✅ |
 | `DiveConfig` — physics / planning / gas config, scoped overrides | ✅ |
-| `DiveProfile` — builder, validation & repair | ✅ |
+| `DiveProfile` — builder, validation & repair, timeline | ✅ |
 | Plugin registry (entry-point deco-model discovery) | ✅ |
-| Deco models (ZHL-16C), ascent planner, reports | 🚧 in progress |
+| Deco models — Bühlmann ZHL-16C (GF), VPM-B (pre-CVA) | ✅ |
+| `DiveResult` — checkpoints, `state_at`/`ceiling_at`/`tts(t)` | ✅ |
+| Ascent planner (`plan_ascent`) + `GasPlan` | ✅ |
+| VPM-B critical-volume/Boyle stage, reports, formatters | 🚧 in progress |
 
 ## Design principles
 
@@ -97,6 +100,20 @@ profile.gas_at(23)                # gas breathed at that moment
 # JSON round-trip:
 profile.to_json(path="dive.json")
 restored = DiveProfile.from_json(path="dive.json")
+```
+
+Running a deco model over the profile and querying the result:
+
+```python
+from diveplan import DiveResult
+from diveplan.models.buhlmann.common import Gradient
+from diveplan.models.buhlmann.zhl16 import ZHL16C
+
+result = DiveResult.run(profile, ZHL16C(gradient=Gradient(0.3, 0.7)))
+result.ceiling_at(23).depth_m   # deco ceiling 23 minutes into the dive
+result.tts(23)                  # time-to-surface if ascending right now
+for t, state in result.tissue_series(1):   # tissue loading, 1-min samples
+    ...
 ```
 
 Segments can still be added explicitly (`add_segment`, `insert_segment_at_index`,

--- a/examples/complete_dive_plan.py
+++ b/examples/complete_dive_plan.py
@@ -140,6 +140,7 @@ ascent = plan_ascent(
     start_pressure=bottom.pressure_at(end),
     gas=bottom.gas_at(end),
     gas_plan=carried,
+    clock_offset=end,  # stop departures on whole minutes of dive runtime
 )
 
 full_dive = bottom.copy()

--- a/examples/complete_dive_plan.py
+++ b/examples/complete_dive_plan.py
@@ -1,0 +1,187 @@
+"""Complete diveplan walkthrough — plan a 40 m trimix-free deco dive on air
+with an EAN50 deco gas, end to end.
+
+Run from the repo root:
+
+    uv run python examples/complete_dive_plan.py
+
+Covers: configuration, gases, fluent profile building, running deco models,
+result queries (ceiling, TTS, tissue loading), ascent planning, model
+comparison, and JSON serialization.
+
+DO NOT USE FOR REAL-WORLD DIVE PLANNING — experimental software.
+"""
+
+from datetime import timedelta
+
+from diveplan import (
+    DiveConfig,
+    DiveProfile,
+    DiveResult,
+    Gas,
+    GasPlan,
+    Pressure,
+    plan_ascent,
+)
+from diveplan.core.dive_segment import DiveSegment, SegmentKind
+from diveplan.models.buhlmann.common import Gradient
+from diveplan.models.buhlmann.zhl16 import ZHL16C
+from diveplan.models.vpm.model import VpmB
+
+
+def minutes(td: timedelta) -> str:
+    return f"{td.total_seconds() / 60:5.1f} min"
+
+
+def describe(segment: DiveSegment, runtime: timedelta) -> str:
+    depth_from = segment.start_pressure.depth_m
+    depth_to = segment.end_pressure.depth_m
+    if segment.kind is SegmentKind.Constant.GAS_SWITCH:
+        what = f"switch to {segment.gas}"
+    elif depth_from == depth_to:
+        what = f"hold {depth_from:4.0f} m"
+    else:
+        what = f"{depth_from:4.0f} m -> {depth_to:3.0f} m"
+    return (
+        f"  {minutes(runtime):>9}  {what:<22} {minutes(segment.duration):>9}"
+        f"   {segment.gas.name:<6} {segment.kind.name}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Configuration — one shared config; mutate it, or override it in a scope
+# ---------------------------------------------------------------------------
+print("=== 1. Configuration ===")
+
+cfg = DiveConfig.current()
+print(f"ascent rate     : {cfg.planning.ascent_rate} m/min")
+print(
+    f"stop grid       : every {cfg.planning.stop_increment_m} m, "
+    f"last at {cfg.planning.last_stop_m} m"
+)
+print(f"deco ppO2 limit : {cfg.gas.deco_ppo2_bar} bar")
+
+# Scoped override (fresh water, altitude...) — nestable, thread-safe:
+sea_level_bar = Pressure.from_depth_m(30).bar
+
+altitude = DiveConfig()
+altitude.physics.surface_pressure_mbar = 900
+altitude.physics.water_density = 1.0
+with altitude:
+    altitude_bar = Pressure.from_depth_m(30).bar
+print(
+    f"30 m of water column = {altitude_bar:.3f} bar at altitude/fresh water, "
+    f"{sea_level_bar:.3f} bar at sea level/salt"
+)
+print()
+
+# ---------------------------------------------------------------------------
+# 2. Gases — named constructors, parsing, limits, best mix
+# ---------------------------------------------------------------------------
+print("=== 2. Gases ===")
+
+air = Gas.air()
+ean50 = Gas.from_name("ean50")  # or Gas.nitrox(0.50)
+
+print(f"EAN50 MOD @1.6 bar : {ean50.mod(ppo2_bar=1.6).depth_m:.1f} m")
+print(f"best mix for 30 m  : {air.best_mix(30)}")
+print(f"air END at 40 m    : {air.end(Pressure.from_depth_m(40)).depth_m:.1f} m")
+print()
+
+# ---------------------------------------------------------------------------
+# 3. Build the bottom portion of the dive — fluent, policy-checked
+# ---------------------------------------------------------------------------
+print("=== 3. Profile (bottom portion) ===")
+
+bottom = (
+    DiveProfile()  # RAISE policy: every seam validated as you build
+    .descend_to("40 m")  # air by default, configured descent rate
+    .stay(25)  # 25 min bottom time
+)
+print(f"segments: {bottom.segment_count}, runtime: {minutes(bottom.runtime)}")
+print(
+    f"depth at t=10 min : {bottom.pressure_at(10).depth_m:.1f} m on {bottom.gas_at(10)}"
+)
+print()
+
+# ---------------------------------------------------------------------------
+# 4. Run a deco model over it and query the result
+# ---------------------------------------------------------------------------
+print("=== 4. DiveResult queries (ZHL-16C, GF 30/70) ===")
+
+zhl = ZHL16C(gradient=Gradient(0.3, 0.7))
+carried = GasPlan([air, ean50])
+
+result = DiveResult.run(bottom, zhl)
+
+for t in (5, 15, bottom.runtime):
+    ceiling = result.ceiling_at(t)
+    depth = max(0.0, ceiling.depth_m)
+    label = minutes(t if isinstance(t, timedelta) else timedelta(minutes=t))
+    print(
+        f"t={label}: ceiling {depth:4.1f} m   "
+        f"TTS {minutes(result.tts(t, gas_plan=carried))}"
+    )
+
+# Tissue loading over time (leading compartment) — feed this to a plot:
+print("leading-compartment N2 tension (mbar):")
+for t, state in result.tissue_series(timedelta(minutes=9)):
+    print(f"  t={minutes(t)}: {state.tissues[0][0]:6.0f}")
+print()
+
+# ---------------------------------------------------------------------------
+# 5. Plan the deco ascent and assemble the full dive
+# ---------------------------------------------------------------------------
+print("=== 5. Ascent plan ===")
+
+end = bottom.runtime
+ascent = plan_ascent(
+    result.model_at(end),  # model positioned at end of bottom time
+    start_pressure=bottom.pressure_at(end),
+    gas=bottom.gas_at(end),
+    gas_plan=carried,
+)
+
+full_dive = bottom.copy()
+full_dive.add_segments(ascent)  # seams stay policy-checked
+
+print("runtime    action                  duration   gas    kind")
+elapsed = timedelta(0)
+for segment in full_dive.segments:
+    print(describe(segment, elapsed))
+    elapsed += segment.duration
+print(f"total runtime : {minutes(full_dive.runtime)}")
+deco_time = sum(
+    (s.duration for s in ascent if s.kind is SegmentKind.Constant.STOP),
+    timedelta(0),
+)
+print(f"total stops   : {minutes(deco_time)}")
+print()
+
+# ---------------------------------------------------------------------------
+# 6. Same dive, different models — the point of the result layer
+# ---------------------------------------------------------------------------
+print("=== 6. Model comparison (same bottom, EAN50 carried) ===")
+
+candidates = [
+    ("ZHL-16C raw", ZHL16C()),
+    ("ZHL-16C GF 30/70", ZHL16C(gradient=Gradient(0.3, 0.7))),
+    ("ZHL-16C GF 85/85", ZHL16C(gradient=Gradient(0.85, 0.85))),
+    ("VPM-B +0 (pre-CVA)", VpmB(conservatism=0)),
+    ("VPM-B +3 (pre-CVA)", VpmB(conservatism=3)),
+]
+for name, model in candidates:
+    res = DiveResult.run(bottom, model)
+    tts = res.tts(bottom.runtime, gas_plan=carried)
+    print(f"  {name:<20} TTS at end of bottom: {minutes(tts)}")
+print()
+
+# ---------------------------------------------------------------------------
+# 7. Serialization — profiles round-trip as JSON, unvalidated
+# ---------------------------------------------------------------------------
+print("=== 7. Serialization ===")
+
+payload = full_dive.to_json()
+restored = DiveProfile.from_json(payload)
+assert restored.segments == full_dive.segments
+print(f"JSON round-trip OK ({len(payload)} bytes, {restored.segment_count} segments)")

--- a/src/diveplan/__init__.py
+++ b/src/diveplan/__init__.py
@@ -33,9 +33,11 @@ from diveplan.core.dive_segment import DiveSegment, SegmentKind
 from diveplan.core.gas import Gas
 from diveplan.core.pressure import Pressure
 
-# Re-exported as subsequent layers are implemented:
-# from diveplan.planning.gas_plan import GasPlan
-# from diveplan.dive.dive_profile import DiveProfile
+# -- dive / planning layers ------------------------------------------------
+from diveplan.dive.dive_profile import DiveProfile
+from diveplan.dive.dive_result import DiveResult
+from diveplan.planning.ascent_plan import plan_ascent
+from diveplan.planning.gas_plan import GasPlan
 
 # -- config proxy --------------------------------------------------------------
 
@@ -90,9 +92,11 @@ __all__ = [
     # configuration
     "DiveConfig",
     "diveconfig",
-    # re-exported as later layers land:
-    # "GasPlan",
-    # "DiveProfile",
+    # dive / planning layers
+    "DiveProfile",
+    "DiveResult",
+    "GasPlan",
+    "plan_ascent",
 ]
 
 __version__ = "0.1.0"

--- a/src/diveplan/dive/dive_profile.py
+++ b/src/diveplan/dive/dive_profile.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
 from datetime import timedelta
 from enum import Enum, auto
-from typing import Any, Optional
+from typing import Any, NamedTuple, Optional
 
 from ..core.config import DiveConfig
 from ..core.dive_segment import DiveSegment, SegmentKind
@@ -14,6 +14,7 @@ from ..utils.conversions import coerce_depth_to_pressure, coerce_gas
 
 __all__ = (
     "DiveProfile",
+    "ProfileSample",
     "ProfileValidationError",
     "ProfileContinuityError",
     "ProfileSimplicityError",
@@ -218,6 +219,21 @@ def _as_timedelta(value: timedelta | float) -> timedelta:
     return timedelta(minutes=value)
 
 
+class ProfileSample(NamedTuple):
+    """One integration step on the profile's global timeline.
+
+    Represents the half-open interval ``(time - dt, time]``: ``pressure`` is
+    the ambient pressure at the *end* of the step (rectangle rule, matching
+    BaseDecoModel), ``gas`` the breathing gas throughout it.
+    """
+
+    time: timedelta
+    dt: timedelta
+    pressure: Pressure
+    gas: Gas
+    segment_index: int
+
+
 # ------------------------------------------------------------------
 # Dive Profile
 # ------------------------------------------------------------------
@@ -375,6 +391,40 @@ class DiveProfile:
         """Breathing gas at runtime `t` (minutes or timedelta)."""
         return self.segment_at(t).gas
 
+    def iter_samples(self, interval: timedelta | float) -> Iterator[ProfileSample]:
+        """Yield integration steps over the whole profile timeline.
+
+        The single sampling authority for model integration and
+        visualization: steps never cross a segment boundary (the last step of
+        each segment is shortened as needed, so boundaries are hit exactly —
+        checkpoints depend on this), zero-duration gas-switch segments yield
+        no step, and each step's dt sums exactly to the total runtime.
+
+        Args:
+            interval: Sample step — minutes as a number, or a timedelta.
+
+        Raises:
+            ValueError: If the interval is not strictly positive.
+        """
+        step_size = _as_timedelta(interval)
+        if step_size <= timedelta(0):
+            raise ValueError(f"Sample interval must be > 0, got {step_size}.")
+
+        elapsed = timedelta(0)
+        for index, segment in enumerate(self._segments):
+            into_segment = timedelta(0)
+            while into_segment < segment.duration:
+                dt = min(step_size, segment.duration - into_segment)
+                into_segment += dt
+                yield ProfileSample(
+                    time=elapsed + into_segment,
+                    dt=dt,
+                    pressure=segment.pressure_at_time(into_segment),
+                    gas=segment.gas,
+                    segment_index=index,
+                )
+            elapsed += segment.duration
+
     # ------------------------------------------------------------------
     # Seam helpers — local (O(1)) validation between two adjacent segments
     # ------------------------------------------------------------------
@@ -386,6 +436,13 @@ class DiveProfile:
             a.kind is SegmentKind.Constant.GAS_SWITCH
             or b.kind is SegmentKind.Constant.GAS_SWITCH
         )
+
+    @staticmethod
+    def _is_mergeable(a: DiveSegment, b: DiveSegment) -> bool:
+        """Adjacent segments are redundant only if fully continuous AND of the
+        same kind — merging a GAS_SWITCH into a stop (or a deco ascent into a
+        forced one) would erase meaningful semantics, not simplify."""
+        return a.kind == b.kind and a.is_fully_continuous_with(b)
 
     def _seam_error(
         self, a: DiveSegment, b: DiveSegment, index: int
@@ -787,7 +844,7 @@ class DiveProfile:
         if not skip_simplicity:
             for i, current in enumerate(self._segments[:-1]):
                 next_seg = self._segments[i + 1]
-                if current.is_fully_continuous_with(next_seg):
+                if self._is_mergeable(current, next_seg):
                     errors.append(ProfileSimplicityError(i, current, next_seg))
 
         return tuple(errors)
@@ -935,7 +992,7 @@ class DiveProfile:
 
         current_merged = self._segments[0]
         for next_seg in self._segments[1:]:
-            if current_merged.is_fully_continuous_with(next_seg):
+            if self._is_mergeable(current_merged, next_seg):
                 current_merged = current_merged.merge_with(next_seg)
             else:
                 simplified.add_segment(current_merged)

--- a/src/diveplan/dive/dive_result.py
+++ b/src/diveplan/dive/dive_result.py
@@ -1,0 +1,176 @@
+"""Result layer: a deco model run over a profile, queryable by time.
+
+The profile stays pure input geometry; everything a model computes lands
+here. A :class:`DiveResult` stores model-state **checkpoints at segment
+boundaries** only — O(segments) memory for batch runs — and answers
+time-addressed queries by re-integrating at most one segment from the
+nearest checkpoint (exact, since Haldane integration composes).
+
+Queries:
+
+- ``state_at(t)`` — model state at any runtime
+- ``ceiling_at(t)`` — ceiling at any runtime
+- ``tissue_series(dt)`` — (time, state) samples for visualization
+- ``tts(t)`` — time-to-surface: a counterfactual ascent planned from the
+  state at ``t`` (see :mod:`diveplan.planning.ascent_plan`)
+
+One profile can be run under any number of models/settings and the results
+compared — nothing here mutates the profile or the caller's model.
+"""
+
+from datetime import timedelta
+from typing import Iterator
+
+from diveplan.core.dive_segment import DiveSegment
+from diveplan.core.gas import Gas
+from diveplan.core.pressure import Pressure
+from diveplan.dive.dive_profile import DiveProfile, _as_timedelta
+from diveplan.models.base import BaseDecoModel, DecoState
+from diveplan.planning.ascent_plan import plan_ascent
+from diveplan.planning.gas_plan import GasPlan
+
+__all__ = ["DiveResult"]
+
+
+class DiveResult[StateT: DecoState]:
+    """A deco model's run over a profile: checkpoints + time queries.
+
+    Build via :meth:`run`. The result owns an independent model copy and a
+    copy of the profile's segment list; neither input is mutated.
+    """
+
+    __slots__ = ("_profile", "_model", "_checkpoints")
+
+    _profile: DiveProfile
+    _model: BaseDecoModel[StateT]
+    _checkpoints: tuple[StateT, ...]
+
+    def __init__(
+        self,
+        profile: DiveProfile,
+        model: BaseDecoModel[StateT],
+        checkpoints: tuple[StateT, ...],
+    ):
+        self._profile = profile
+        self._model = model
+        self._checkpoints = checkpoints
+
+    @classmethod
+    def run(
+        cls, profile: DiveProfile, model: BaseDecoModel[StateT]
+    ) -> "DiveResult[StateT]":
+        """Integrate `model` over `profile` and capture boundary checkpoints.
+
+        The caller's model is copied, not mutated — run the same profile
+        under several models/settings and compare. The profile is integrated
+        as-is; validate/repair it first if it may be discontinuous.
+        """
+        work = model.copy()
+        checkpoints = [work.get_state()]
+        for segment in profile.segments:
+            checkpoints.append(work.integrate_segment(segment))
+        return cls(profile.copy(), work, tuple(checkpoints))
+
+    # ------------------------------------------------------------------
+    # Accessors
+    # ------------------------------------------------------------------
+
+    @property
+    def profile(self) -> DiveProfile:
+        """The dive profile this result was computed from (own copy)."""
+        return self._profile
+
+    @property
+    def checkpoints(self) -> tuple[StateT, ...]:
+        """Model states at segment boundaries; ``[0]`` is the pre-dive state,
+        ``[i]`` the state after segment ``i-1``."""
+        return self._checkpoints
+
+    @property
+    def final_state(self) -> StateT:
+        """Model state at the end of the profile."""
+        return self._checkpoints[-1]
+
+    def model_at(self, t: timedelta | float) -> BaseDecoModel[StateT]:
+        """Independent model instance positioned at runtime `t`.
+
+        Restores the checkpoint before `t`'s segment and re-integrates the
+        partial segment — exact, since Haldane integration composes. The
+        returned model is yours: integrating it further does not touch the
+        result.
+        """
+        index = self._profile.segment_index_at(t)
+        offset = _as_timedelta(t) - self._profile.start_time_of_segment(index)
+        segment = self._profile.segments[index]
+
+        work = self._model.copy()
+        work.set_state(self._checkpoints[index])
+        if offset > timedelta(0):
+            partial = DiveSegment(
+                segment.start_pressure,
+                segment.pressure_at_time(offset),
+                offset,
+                segment.gas,
+            )
+            work.integrate_segment(partial)
+        return work
+
+    # ------------------------------------------------------------------
+    # Queries
+    # ------------------------------------------------------------------
+
+    def state_at(self, t: timedelta | float) -> StateT:
+        """Model state at runtime `t` (minutes or timedelta)."""
+        return self.model_at(t).get_state()
+
+    def ceiling_at(self, t: timedelta | float) -> Pressure:
+        """Deco ceiling at runtime `t`."""
+        return self.model_at(t).get_ceiling()
+
+    def tissue_series(
+        self, interval: timedelta | float
+    ) -> Iterator[tuple[timedelta, StateT]]:
+        """Yield (time, state) at each sample step — for tissue plots.
+
+        Starts with the pre-dive state at t=0, then one snapshot per profile
+        sample (see :meth:`DiveProfile.iter_samples`).
+        """
+        work = self._model.copy()
+        work.set_state(self._checkpoints[0])
+        yield (timedelta(0), work.get_state())
+        for sample in self._profile.iter_samples(interval):
+            work.integrate(sample.pressure, sample.gas, sample.dt)
+            yield (sample.time, work.get_state())
+
+    def tts(self, t: timedelta | float, gas_plan: GasPlan | None = None) -> timedelta:
+        """Time-to-surface at runtime `t`: the duration of an ascent planned
+        from the model state, depth, and gas at that moment.
+
+        Args:
+            t: Runtime to ask "if I ascended now, how long?" at.
+            gas_plan: Deco gases available for the hypothetical ascent.
+                Defaults to all gases appearing in the profile.
+        """
+        if gas_plan is None:
+            gas_plan = GasPlan(self._unique_gases())
+        ascent = plan_ascent(
+            self.model_at(t),
+            start_pressure=self._profile.pressure_at(t),
+            gas=self._profile.gas_at(t),
+            gas_plan=gas_plan,
+        )
+        return sum((s.duration for s in ascent), timedelta(0))
+
+    def _unique_gases(self) -> list[Gas]:
+        gases: list[Gas] = []
+        for segment in self._profile.segments:
+            if segment.gas not in gases:
+                gases.append(segment.gas)
+        return gases
+
+    def __repr__(self) -> str:
+        return (
+            f"DiveResult({type(self._model).__name__}, "
+            f"{self._profile.segment_count} segments, "
+            f"runtime={self._profile.runtime})"
+        )

--- a/src/diveplan/dive/dive_result.py
+++ b/src/diveplan/dive/dive_result.py
@@ -158,6 +158,7 @@ class DiveResult[StateT: DecoState]:
             start_pressure=self._profile.pressure_at(t),
             gas=self._profile.gas_at(t),
             gas_plan=gas_plan,
+            clock_offset=t,  # stop departures align to the dive clock
         )
         return sum((s.duration for s in ascent), timedelta(0))
 

--- a/src/diveplan/models/base.py
+++ b/src/diveplan/models/base.py
@@ -10,7 +10,7 @@ what counterfactual queries (TTS at time t) resume from.
 
 from abc import ABC, abstractmethod
 from datetime import timedelta
-from typing import ClassVar
+from typing import ClassVar, Self
 
 from diveplan.core.dive_segment import DiveSegment
 from diveplan.core.gas import Gas
@@ -65,6 +65,19 @@ class BaseDecoModel[StateT: DecoState](ABC):
 
         return self._get_deco_state()
 
+    def get_state(self) -> StateT:
+        """Snapshot the current model state (public accessor)."""
+        return self._get_deco_state()
+
+    def integrate(self, pressure: Pressure, gas: Gas, dt: timedelta) -> None:
+        """Advance the model by a single step at the given pressure and gas.
+
+        Public stepwise entry point for consumers that drive their own sample
+        loop (result layer, planner); ``integrate_segment`` remains the
+        segment-level API.
+        """
+        self._integrate_model(pressure, gas, dt)
+
     @abstractmethod
     def _integrate_model(self, pressure: Pressure, gas: Gas, dt: timedelta) -> None:
         """Advance the model by dt at the given ambient pressure and gas."""
@@ -76,3 +89,16 @@ class BaseDecoModel[StateT: DecoState](ABC):
     @abstractmethod
     def get_ceiling(self) -> Pressure:
         """Return the current ceiling depth."""
+
+    @abstractmethod
+    def set_state(self, state: StateT) -> None:
+        """Restore the model to a previously snapshotted state (lossless).
+
+        Together with :meth:`copy`, this is the checkpointing contract the
+        result layer relies on for state-at-time and counterfactual (TTS)
+        queries.
+        """
+
+    @abstractmethod
+    def copy(self) -> Self:
+        """Independent clone with identical configuration and current state."""

--- a/src/diveplan/planning/__init__.py
+++ b/src/diveplan/planning/__init__.py
@@ -1,0 +1,6 @@
+"""Ascent planning: deco schedules and gas selection."""
+
+from diveplan.planning.ascent_plan import AscentNotConvergingError, plan_ascent
+from diveplan.planning.gas_plan import GasPlan
+
+__all__ = ["plan_ascent", "GasPlan", "AscentNotConvergingError"]

--- a/src/diveplan/planning/ascent_plan.py
+++ b/src/diveplan/planning/ascent_plan.py
@@ -78,6 +78,7 @@ def plan_ascent(
     start_pressure: Pressure,
     gas: Gas,
     gas_plan: Optional[GasPlan] = None,
+    clock_offset: timedelta | float = timedelta(0),
 ) -> list[DiveSegment]:
     """Plan the decompression ascent from the given position and model state.
 
@@ -88,6 +89,13 @@ def plan_ascent(
         gas: Gas currently being breathed.
         gas_plan: Gases available for switches during the ascent. Defaults
             to just the current gas.
+        clock_offset: Dive runtime at which this ascent starts (minutes or
+            timedelta). Stop departures are extended to whole multiples of
+            ``min_stop_time_s`` on this clock — the dive-table convention
+            (a stop ends at e.g. runtime 31:00, not 30:26), which keeps
+            schedules comparable with planners like Subsurface. Pass the
+            bottom runtime when planning a real dive; the default plans on
+            an ascent-relative clock.
 
     Returns:
         Continuous segments from `start_pressure` to the surface: deco
@@ -103,12 +111,27 @@ def plan_ascent(
 
     if gas_plan is None:
         gas_plan = GasPlan([gas])
+    if not isinstance(clock_offset, timedelta):
+        clock_offset = timedelta(minutes=clock_offset)
 
     work = model.copy()
     current = start_pressure
     current_gas = gas
     first_stop: Optional[Pressure] = None
     plan: list[DiveSegment] = []
+
+    def runtime_now() -> timedelta:
+        return clock_offset + sum((s.duration for s in plan), timedelta(0))
+
+    def wait_duration() -> timedelta:
+        """Wait until the next whole stop-time boundary on the dive clock."""
+        increment = float(planning.min_stop_time_s)
+        into_increment = runtime_now().total_seconds() % increment
+        remaining = increment - into_increment
+        # Already (numerically) on a boundary: wait a full increment.
+        if remaining < 0.5:
+            remaining += increment
+        return timedelta(seconds=remaining)
 
     def integrate_and_append(segment: DiveSegment) -> None:
         work.integrate_segment(segment)
@@ -172,7 +195,7 @@ def plan_ascent(
         chunk = DiveSegment(
             current,
             current,
-            timedelta(seconds=planning.min_stop_time_s),
+            wait_duration(),
             current_gas,
             constant_kind=SegmentKind.Constant.STOP,
         )

--- a/src/diveplan/planning/ascent_plan.py
+++ b/src/diveplan/planning/ascent_plan.py
@@ -1,0 +1,194 @@
+"""Ascent planner: compute the decompression schedule from a model state.
+
+``plan_ascent`` is a pure function of (model state, position, gases,
+config) → list of DiveSegments. It clones the model and never mutates the
+caller's — the property that makes TTS/counterfactual queries safe.
+
+Algorithm (standard staged-decompression loop):
+
+1. From the current depth, find the shallowest reachable target — the
+   surface, or the deepest required stop on the configured stop grid
+   (``stop_increment_m``, cut off at ``last_stop_m``).
+2. Ascend there at ``ascent_rate`` (integrating the ascent into the model).
+3. At a stop: switch to the best deco gas (richest ppO2-safe mix from the
+   gas plan), then wait in ``min_stop_time_s`` increments until the next
+   shallower target clears.
+4. Repeat until surfaced.
+
+Gradient-factor models: the ceiling test for a target uses the GF
+interpolated at that target's depth (GF-low anchored at the deepest stop of
+*this* ascent, GF-high at the surface). Until the first stop is known the
+conservative GF-low applies. Non-GF models (VPM-B) are asked for their plain
+ceiling; note that VPM-B's Critical Volume Algorithm and Boyle compensation
+are not applied yet — its schedules use the conservative pre-CVA gradients.
+"""
+
+from datetime import timedelta
+from typing import Any, Optional
+
+from diveplan.core.config import DiveConfig
+from diveplan.core.dive_segment import DiveSegment, SegmentKind
+from diveplan.core.gas import Gas
+from diveplan.core.pressure import Pressure
+from diveplan.models.base import BaseDecoModel
+from diveplan.models.buhlmann.model import BuhlmannModel
+from diveplan.planning.gas_plan import GasPlan
+
+__all__ = ["plan_ascent", "AscentNotConvergingError"]
+
+# Hard cap on planning loop iterations — a schedule requiring more stop time
+# than this is a bug (or an unsurfaceable profile), not a dive plan.
+_MAX_ITERATIONS = 100_000
+
+
+class AscentNotConvergingError(RuntimeError):
+    """The stop loop failed to clear the next target within the iteration cap."""
+
+
+def _ceiling(
+    model: BaseDecoModel[Any],
+    target: Pressure,
+    first_stop: Optional[Pressure],
+) -> Pressure:
+    """Model ceiling for an ascent-to-`target` test.
+
+    GF models interpolate the gradient factor at the target depth once the
+    first (deepest) stop is anchored; before that, and for non-GF models,
+    the model's default (conservative) ceiling applies.
+    """
+    if isinstance(model, BuhlmannModel) and first_stop is not None:
+        return model.get_ceiling(model.gradient.factor(target, first_stop))
+    return model.get_ceiling()
+
+
+def _next_targets(current: Pressure) -> list[Pressure]:
+    """Candidate ascent targets from shallowest to deepest: the surface, then
+    the stop grid from last_stop_m down to just above `current`."""
+    planning = DiveConfig.current().planning
+    targets = [Pressure.surface()]
+    depth = planning.last_stop_m
+    while Pressure.from_depth_m(depth) < current:
+        targets.append(Pressure.from_depth_m(depth))
+        depth += planning.stop_increment_m
+    return targets
+
+
+def plan_ascent(
+    model: BaseDecoModel[Any],
+    start_pressure: Pressure,
+    gas: Gas,
+    gas_plan: Optional[GasPlan] = None,
+) -> list[DiveSegment]:
+    """Plan the decompression ascent from the given position and model state.
+
+    Args:
+        model: Deco model holding the tissue state at `start_pressure`.
+            Cloned internally — the caller's instance is not touched.
+        start_pressure: Current ambient pressure.
+        gas: Gas currently being breathed.
+        gas_plan: Gases available for switches during the ascent. Defaults
+            to just the current gas.
+
+    Returns:
+        Continuous segments from `start_pressure` to the surface: deco
+        ascents, stops, and gas switches. Empty if already at the surface.
+
+    Raises:
+        AscentNotConvergingError: If stops fail to clear within the
+            iteration cap (pathological state or misconfiguration).
+    """
+    planning = DiveConfig.current().planning
+    gas_limits = DiveConfig.current().gas
+    surface = Pressure.surface()
+
+    if gas_plan is None:
+        gas_plan = GasPlan([gas])
+
+    work = model.copy()
+    current = start_pressure
+    current_gas = gas
+    first_stop: Optional[Pressure] = None
+    plan: list[DiveSegment] = []
+
+    def integrate_and_append(segment: DiveSegment) -> None:
+        work.integrate_segment(segment)
+        plan.append(segment)
+
+    def ascend_to(target: Pressure) -> None:
+        depth_change = current.depth_m - target.depth_m
+        leg = DiveSegment(
+            current,
+            target,
+            depth_change / planning.ascent_rate,
+            current_gas,
+            ascent_kind=SegmentKind.Ascent.DECO_ASCENT,
+        )
+        work.integrate_segment(leg)
+        # Off-gassing during an ascent can clear the next target immediately;
+        # fold such continuation legs into one segment instead of stacking
+        # rate-identical back-to-back ascents.
+        if plan and plan[-1].is_fully_continuous_with(leg):
+            plan[-1] = plan[-1].merge_with(leg)
+        else:
+            plan.append(leg)
+
+    def reachable(target: Pressure) -> bool:
+        return _ceiling(work, target, first_stop) <= target
+
+    for _ in range(_MAX_ITERATIONS):
+        if current <= surface:
+            return plan
+
+        # Shallowest target we may ascend to right now.
+        target = next((p for p in _next_targets(current) if reachable(p)), None)
+
+        if target is not None:
+            ascend_to(target)
+            current = target
+            if current <= surface:
+                return plan
+            continue
+
+        # No target clears: `current` is a stop. The first (deepest) stop of
+        # the ascent anchors GF-low for gradient-factor interpolation.
+        if first_stop is None:
+            first_stop = current
+
+        best = gas_plan.best_gas_at(current)
+        if best is not None and best != current_gas and best.fo2 > current_gas.fo2:
+            switch = DiveSegment(
+                current,
+                current,
+                gas_limits.gas_switch_minutes,
+                best,
+                constant_kind=SegmentKind.Constant.GAS_SWITCH,
+            )
+            if switch.duration > timedelta(0):
+                integrate_and_append(switch)
+            else:
+                plan.append(switch)  # instant switch — nothing to integrate
+            current_gas = best
+
+        chunk = DiveSegment(
+            current,
+            current,
+            timedelta(seconds=planning.min_stop_time_s),
+            current_gas,
+            constant_kind=SegmentKind.Constant.STOP,
+        )
+        work.integrate_segment(chunk)
+        # Extend the previous stop segment instead of stacking 1-min chunks.
+        if (
+            plan
+            and plan[-1].kind is SegmentKind.Constant.STOP
+            and plan[-1].gas == current_gas
+            and plan[-1].start_pressure == current
+        ):
+            plan[-1] = plan[-1].merge_with(chunk)
+        else:
+            plan.append(chunk)
+
+    raise AscentNotConvergingError(
+        f"Ascent from {start_pressure} did not surface within "
+        f"{_MAX_ITERATIONS} planning iterations."
+    )

--- a/src/diveplan/planning/gas_plan.py
+++ b/src/diveplan/planning/gas_plan.py
@@ -1,0 +1,56 @@
+"""Gas plan: the set of gases carried on a dive, and which to breathe when.
+
+Selection reads the ppO2 limits from ``DiveConfig.current().gas`` at call
+time: a gas is usable at a pressure if its ppO2 sits within
+``[min_ppo2_bar, deco_ppo2_bar]`` (the deco limit — the planner switches
+gases during ascent, where the deco ppO2 applies). Among usable gases the
+richest (highest fO2) wins: it off-gasses inert load fastest.
+"""
+
+from collections.abc import Iterable
+from typing import Optional
+
+from diveplan.core.config import DiveConfig
+from diveplan.core.gas import Gas
+from diveplan.core.pressure import Pressure
+
+__all__ = ["GasPlan"]
+
+
+class GasPlan:
+    """An ordered collection of carried gases with depth-based selection."""
+
+    __slots__ = ("_gases",)
+
+    _gases: tuple[Gas, ...]
+
+    def __init__(self, gases: Iterable[Gas]):
+        unique: list[Gas] = []
+        for gas in gases:
+            if gas not in unique:
+                unique.append(gas)
+        if not unique:
+            raise ValueError("GasPlan needs at least one gas.")
+        self._gases = tuple(unique)
+
+    @property
+    def gases(self) -> tuple[Gas, ...]:
+        """The carried gases (duplicates removed, insertion order)."""
+        return self._gases
+
+    @staticmethod
+    def is_breathable(gas: Gas, pressure: Pressure) -> bool:
+        """Whether `gas` is within the configured deco ppO2 window here."""
+        limits = DiveConfig.current().gas
+        ppo2 = gas.ppo2(pressure).bar
+        return limits.min_ppo2_bar <= ppo2 <= limits.deco_ppo2_bar
+
+    def best_gas_at(self, pressure: Pressure) -> Optional[Gas]:
+        """Richest breathable gas at `pressure`, or None if none qualifies."""
+        candidates = [g for g in self._gases if self.is_breathable(g, pressure)]
+        if not candidates:
+            return None
+        return max(candidates, key=lambda g: g.fo2)
+
+    def __repr__(self) -> str:
+        return f"GasPlan({', '.join(str(g) for g in self._gases)})"

--- a/tests/test_dive_result.py
+++ b/tests/test_dive_result.py
@@ -1,0 +1,242 @@
+"""
+Tests for diveplan.dive.dive_result (and DiveProfile.iter_samples).
+
+Key invariants: iter_samples steps tile the runtime exactly and never cross
+segment boundaries; running a model through iter_samples reproduces
+integrate_segment (integration composes); checkpoint-based state_at(t) is
+exact, not approximate; nothing mutates the caller's profile or model.
+"""
+
+from datetime import timedelta
+
+import pytest
+
+from diveplan.core.gas import Gas
+from diveplan.dive.dive_profile import DiveProfile
+from diveplan.dive.dive_result import DiveResult
+from diveplan.models.buhlmann.common import Gradient
+from diveplan.models.buhlmann.zhl16 import ZHL16C
+from diveplan.models.vpm.model import VpmB
+
+AIR = Gas.air()
+
+
+def simple_profile() -> DiveProfile:
+    """Surface → 30 m → 20 min bottom → surface (all air, RAISE-valid)."""
+    return DiveProfile().descend_to("30 m").stay(20).surface()
+
+
+def switch_profile() -> DiveProfile:
+    """Deco-style profile with a gas switch during the ascent."""
+    return (
+        DiveProfile()
+        .descend_to("40 m")
+        .stay(25)
+        .ascend_to("21 m")
+        .switch_gas("ean50")
+        .stay(3)
+        .surface()
+    )
+
+
+# ------------------------------------------------------------------
+# DiveProfile.iter_samples
+# ------------------------------------------------------------------
+
+
+class TestIterSamples:
+    def test_steps_tile_the_runtime(self):
+        profile = switch_profile()
+        samples = list(profile.iter_samples(timedelta(seconds=7)))  # awkward step
+        total = sum((s.dt for s in samples), timedelta(0))
+        assert total == profile.runtime
+        assert samples[-1].time == profile.runtime
+
+    def test_steps_never_cross_segment_boundaries(self):
+        profile = switch_profile()
+        for sample in profile.iter_samples(timedelta(seconds=7)):
+            start = profile.start_time_of_segment(sample.segment_index)
+            segment = profile.segments[sample.segment_index]
+            assert start < sample.time <= start + segment.duration
+
+    def test_boundaries_hit_exactly(self):
+        profile = simple_profile()
+        times = {s.time for s in profile.iter_samples(timedelta(seconds=13))}
+        for i in range(profile.segment_count):
+            assert (
+                profile.start_time_of_segment(i) + profile.segments[i].duration
+            ) in times
+
+    def test_pressure_is_end_of_interval(self):
+        profile = simple_profile()
+        first = next(iter(profile.iter_samples(timedelta(seconds=30))))
+        assert first.pressure == profile.segments[0].pressure_at_time(first.dt)
+
+    def test_gas_follows_segments(self):
+        profile = switch_profile()
+        ean50 = Gas.from_name("ean50")
+        gases = {s.gas for s in profile.iter_samples(1)}
+        assert gases == {AIR, ean50}
+
+    def test_zero_duration_switch_yields_no_step(self):
+        from diveplan.core.config import DiveConfig
+
+        DiveConfig.current().gas.gas_switch_minutes = 0
+        profile = DiveProfile().descend_to("30 m").switch_gas("ean32")
+        switch_index = profile.segment_count - 1
+        assert all(s.segment_index != switch_index for s in profile.iter_samples(1))
+
+    def test_interval_validation(self):
+        with pytest.raises(ValueError, match="> 0"):
+            list(simple_profile().iter_samples(0))
+
+    def test_matches_integrate_segment(self):
+        # Driving a model through iter_samples must equal the segment API.
+        profile = switch_profile()
+        via_segments = ZHL16C()
+        for segment in profile.segments:
+            via_segments.integrate_segment(segment)
+
+        via_samples = ZHL16C()
+        for sample in profile.iter_samples(
+            timedelta(seconds=via_samples.sample_rate_seconds)
+        ):
+            via_samples.integrate(sample.pressure, sample.gas, sample.dt)
+
+        for (n2_a, he_a), (n2_b, he_b) in zip(
+            via_segments.get_state().tissues,
+            via_samples.get_state().tissues,
+            strict=True,
+        ):
+            assert n2_a == pytest.approx(n2_b, rel=1e-9)
+            assert he_a == pytest.approx(he_b, rel=1e-9)
+
+
+# ------------------------------------------------------------------
+# DiveResult
+# ------------------------------------------------------------------
+
+
+class TestDiveResultRun:
+    def test_checkpoint_shape(self):
+        profile = simple_profile()
+        result = DiveResult.run(profile, ZHL16C())
+        assert len(result.checkpoints) == profile.segment_count + 1
+        assert result.checkpoints[0] == ZHL16C().get_state()  # pre-dive
+        assert result.final_state == result.checkpoints[-1]
+
+    def test_caller_model_and_profile_untouched(self):
+        profile = simple_profile()
+        model = ZHL16C()
+        before = model.get_state()
+        segment_count = profile.segment_count
+        DiveResult.run(profile, model)
+        assert model.get_state() == before
+        assert profile.segment_count == segment_count
+
+    def test_result_profile_is_a_copy(self):
+        profile = simple_profile()
+        result = DiveResult.run(profile, ZHL16C())
+        assert result.profile is not profile
+        assert result.profile.segments == profile.segments
+
+    def test_generic_over_models(self):
+        profile = simple_profile()
+        for model in (ZHL16C(gradient=Gradient(0.3, 0.85)), VpmB(conservatism=1)):
+            result = DiveResult.run(profile, model)
+            assert len(result.checkpoints) == profile.segment_count + 1
+
+
+class TestDiveResultQueries:
+    def test_state_at_boundaries_equals_checkpoints(self):
+        profile = simple_profile()
+        result = DiveResult.run(profile, ZHL16C())
+        assert result.state_at(0) == result.checkpoints[0]
+        assert result.state_at(profile.runtime) == result.final_state
+
+    def test_state_at_mid_segment_is_exact(self):
+        # state_at re-integrates from the checkpoint; compare against a
+        # model integrated directly to the same instant.
+        profile = simple_profile()
+        result = DiveResult.run(profile, ZHL16C())
+        t = profile.start_time_of_segment(1) + timedelta(minutes=7)
+
+        direct = ZHL16C()
+        direct.integrate_segment(profile.segments[0])
+        from diveplan.core.dive_segment import DiveSegment
+
+        seg = profile.segments[1]
+        direct.integrate_segment(
+            DiveSegment(seg.start_pressure, seg.start_pressure, 7, seg.gas)
+        )
+
+        for (a_n2, a_he), (b_n2, b_he) in zip(
+            result.state_at(t).tissues, direct.get_state().tissues, strict=True
+        ):
+            assert a_n2 == pytest.approx(b_n2, rel=1e-9)
+            assert a_he == pytest.approx(b_he, rel=1e-9)
+
+    def test_ceiling_rises_with_bottom_time(self):
+        profile = simple_profile()
+        result = DiveResult.run(profile, ZHL16C())
+        bottom_start = profile.start_time_of_segment(1)
+        early = result.ceiling_at(bottom_start + timedelta(minutes=2))
+        late = result.ceiling_at(bottom_start + timedelta(minutes=19))
+        assert late > early
+
+    def test_tissue_series_shape(self):
+        profile = simple_profile()
+        result = DiveResult.run(profile, ZHL16C())
+        series = list(result.tissue_series(timedelta(minutes=1)))
+        assert series[0][0] == timedelta(0)
+        assert series[0][1] == result.checkpoints[0]
+        assert series[-1][0] == profile.runtime
+
+    def test_tissue_series_matches_checkpoints_at_model_rate(self):
+        # Sampled at the model's own rate, the series must land exactly on
+        # the final checkpoint (the rectangle rule reproduces only at the
+        # same step size — coarser sampling is approximate by design).
+        profile = simple_profile()
+        model = ZHL16C()
+        result = DiveResult.run(profile, model)
+        series = list(
+            result.tissue_series(timedelta(seconds=model.sample_rate_seconds))
+        )
+        for (a_n2, a_he), (b_n2, b_he) in zip(
+            series[-1][1].tissues, result.final_state.tissues, strict=True
+        ):
+            assert a_n2 == pytest.approx(b_n2, rel=1e-9)
+            assert a_he == pytest.approx(b_he, rel=1e-9)
+
+    def test_queries_do_not_mutate_result(self):
+        profile = simple_profile()
+        result = DiveResult.run(profile, ZHL16C())
+        final_before = result.final_state
+        result.state_at(5)
+        result.ceiling_at(15)
+        list(result.tissue_series(5))
+        assert result.final_state == final_before
+
+    def test_tts_no_deco_dive_is_ascent_time_only(self):
+        from diveplan.core.config import DiveConfig
+
+        profile = DiveProfile().descend_to("12 m").stay(10).surface()
+        result = DiveResult.run(profile, ZHL16C())
+        t = profile.start_time_of_segment(1) + timedelta(minutes=5)
+        expected = timedelta(minutes=12 / DiveConfig.current().planning.ascent_rate)
+        assert abs(result.tts(t) - expected) < timedelta(seconds=5)
+
+    def test_tts_grows_with_bottom_time_on_deco_dive(self):
+        profile = (
+            DiveProfile(  # long deep bottom, air only
+            )
+            .descend_to("40 m")
+            .stay(30)
+            .surface()
+        )
+        result = DiveResult.run(profile, ZHL16C(gradient=Gradient(0.3, 0.7)))
+        bottom_start = profile.start_time_of_segment(1)
+        early = result.tts(bottom_start + timedelta(minutes=5))
+        late = result.tts(bottom_start + timedelta(minutes=25))
+        assert late > early
+        assert late > timedelta(minutes=10)  # real deco obligation

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -200,6 +200,28 @@ class TestPlanAscentDeco:
         assert GasPlan.is_breathable(EAN50, switches[0].start_pressure)
         assert_plan_well_formed(with_deco_gas, Pressure.from_depth_m(40))
 
+    def test_stop_departures_align_to_dive_clock(self):
+        # Dive-table convention (matches Subsurface): stops are extended so
+        # that departures land on whole min_stop_time boundaries of the dive
+        # clock, even though ascent legs arrive at fractional times.
+        bottom_runtime = timedelta(minutes=27)
+        model = loaded_model(40, 25, Gradient(0.3, 0.7))
+        plan = plan_ascent(
+            model,
+            Pressure.from_depth_m(40),
+            AIR,
+            gas_plan=GasPlan([AIR, EAN50]),
+            clock_offset=bottom_runtime,
+        )
+        elapsed = bottom_runtime
+        for segment in plan:
+            elapsed += segment.duration
+            if segment.kind is SegmentKind.Constant.STOP:
+                departure_s = elapsed.total_seconds()
+                assert departure_s % 60 == pytest.approx(0, abs=0.51) or (
+                    60 - departure_s % 60
+                ) < 0.51
+
     def test_vpm_plan_terminates_and_is_well_formed(self):
         model = VpmB()
         p30 = Pressure.from_depth_m(30)

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -1,0 +1,210 @@
+"""
+Tests for diveplan.planning (GasPlan, plan_ascent).
+
+Planner checks are structural properties every valid schedule must satisfy:
+segments are continuous from the start pressure to the surface, stops sit on
+the configured grid and get monotonically shallower, the model's ceiling is
+respected at every stop departure, and lower gradient factors produce longer
+schedules. No external dive-table vectors — those depend on implementation
+details (rounding, min stop time) that vary between planners.
+"""
+
+from datetime import timedelta
+
+import pytest
+
+from diveplan.core.config import DiveConfig
+from diveplan.core.dive_segment import DiveSegment, SegmentKind
+from diveplan.core.gas import Gas
+from diveplan.core.pressure import Pressure
+from diveplan.dive.dive_profile import DiveProfile, ProfileBuilderPolicy
+from diveplan.models.buhlmann.common import Gradient
+from diveplan.models.buhlmann.zhl16 import ZHL16C
+from diveplan.models.vpm.model import VpmB
+from diveplan.planning.ascent_plan import plan_ascent
+from diveplan.planning.gas_plan import GasPlan
+
+AIR = Gas.air()
+EAN50 = Gas.nitrox(0.50)
+OXYGEN = Gas.oxygen()
+
+
+def loaded_model(depth_m: float, minutes: float, gradient: Gradient) -> ZHL16C:
+    model = ZHL16C(gradient=gradient)
+    p = Pressure.from_depth_m(depth_m)
+    model.integrate_segment(DiveSegment(Pressure.surface(), p, depth_m / 20, AIR))
+    model.integrate_segment(DiveSegment(p, p, minutes, AIR))
+    return model
+
+
+def total_time(plan: list[DiveSegment]) -> timedelta:
+    return sum((s.duration for s in plan), timedelta(0))
+
+
+# ------------------------------------------------------------------
+# GasPlan
+# ------------------------------------------------------------------
+
+
+class TestGasPlan:
+    def test_needs_a_gas(self):
+        with pytest.raises(ValueError):
+            GasPlan([])
+
+    def test_deduplicates_preserving_order(self):
+        plan = GasPlan([AIR, EAN50, AIR])
+        assert plan.gases == (AIR, EAN50)
+
+    def test_breathability_window(self):
+        # EAN50 at 21 m: ppO2 ≈ 1.56 bar — inside the 1.6 deco limit.
+        assert GasPlan.is_breathable(EAN50, Pressure.from_depth_m(21))
+        # EAN50 at 30 m: ppO2 ≈ 2.0 bar — out.
+        assert not GasPlan.is_breathable(EAN50, Pressure.from_depth_m(30))
+        # Air at the surface is fine; oxygen at 30 m is not.
+        assert GasPlan.is_breathable(AIR, Pressure.surface())
+        assert not GasPlan.is_breathable(OXYGEN, Pressure.from_depth_m(30))
+
+    def test_hypoxic_floor(self):
+        trimix_10_70 = Gas.trimix(0.10, 0.70)
+        assert not GasPlan.is_breathable(trimix_10_70, Pressure.surface())
+
+    def test_best_gas_picks_richest_usable(self):
+        plan = GasPlan([AIR, EAN50, OXYGEN])
+        assert plan.best_gas_at(Pressure.from_depth_m(21)) == EAN50
+        assert plan.best_gas_at(Pressure.from_depth_m(3)) == OXYGEN
+        assert plan.best_gas_at(Pressure.from_depth_m(35)) == AIR
+
+    def test_best_gas_none_when_nothing_usable(self):
+        plan = GasPlan([OXYGEN])
+        assert plan.best_gas_at(Pressure.from_depth_m(35)) is None
+
+    def test_limits_read_from_config(self):
+        DiveConfig.current().gas.deco_ppo2_bar = 1.4
+        assert not GasPlan.is_breathable(EAN50, Pressure.from_depth_m(21))
+
+
+# ------------------------------------------------------------------
+# plan_ascent
+# ------------------------------------------------------------------
+
+
+def assert_plan_well_formed(
+    plan: list[DiveSegment], start: Pressure, planning_cfg=None
+) -> None:
+    """Structural invariants every ascent plan must satisfy."""
+    planning = planning_cfg or DiveConfig.current().planning
+    assert plan, "plan must not be empty"
+    assert plan[0].start_pressure == start
+    assert plan[-1].end_pressure == Pressure.surface()
+
+    # Continuous, monotonically shallower (constant segments hold depth).
+    # (validate_profile needs >= 2 segments; a direct ascent is one.)
+    if len(plan) >= 2:
+        profile = DiveProfile(ProfileBuilderPolicy.ALLOW_BAD_PROFILE)
+        profile.add_segments(plan)
+        assert profile.validate_profile() == ()
+    depths = [s.start_pressure for s in plan]
+    assert all(a >= b for a, b in zip(depths, depths[1:], strict=False))
+
+    # Stops sit on the configured grid, at or below the last-stop depth.
+    for segment in plan:
+        if segment.kind is SegmentKind.Constant.STOP:
+            depth = segment.start_pressure.depth_m
+            assert depth >= planning.last_stop_m - 0.01
+            remainder = depth % planning.stop_increment_m
+            assert min(remainder, planning.stop_increment_m - remainder) < 0.05
+
+
+class TestPlanAscentNoDeco:
+    def test_direct_ascent_when_no_ceiling(self):
+        model = loaded_model(12, 10, Gradient(1.0, 1.0))
+        plan = plan_ascent(model, Pressure.from_depth_m(12), AIR)
+        assert_plan_well_formed(plan, Pressure.from_depth_m(12))
+        assert len(plan) == 1
+        assert plan[0].kind is SegmentKind.Ascent.DECO_ASCENT
+
+    def test_already_at_surface(self):
+        plan = plan_ascent(ZHL16C(), Pressure.surface(), AIR)
+        assert plan == []
+
+    def test_input_model_not_mutated(self):
+        model = loaded_model(40, 25, Gradient(0.3, 0.7))
+        before = model.get_state()
+        plan_ascent(model, Pressure.from_depth_m(40), AIR)
+        assert model.get_state() == before
+
+
+class TestPlanAscentDeco:
+    def test_deco_schedule_structure(self):
+        model = loaded_model(40, 25, Gradient(0.3, 0.7))
+        plan = plan_ascent(model, Pressure.from_depth_m(40), AIR)
+        assert_plan_well_formed(plan, Pressure.from_depth_m(40))
+        stops = [s for s in plan if s.kind is SegmentKind.Constant.STOP]
+        assert stops, "a 25 min dive at 40 m on air must require stops"
+        # Consecutive same-depth stop chunks are merged into one segment.
+        stop_depths = [s.start_pressure for s in stops]
+        assert len(stop_depths) == len(set(stop_depths))
+
+    def test_ceiling_respected_at_every_waypoint(self):
+        # Re-run the plan through an independent model: after each segment,
+        # the diver must never be shallower than the ceiling prevailing at
+        # that moment (continuation ascents make departure-time checks too
+        # strict — off-gassing en route is what clears the next target).
+        gradient = Gradient(0.3, 0.7)
+        model = loaded_model(40, 25, gradient)
+        plan = plan_ascent(model, Pressure.from_depth_m(40), AIR)
+
+        first_stop = next(
+            (s.start_pressure for s in plan if s.kind is SegmentKind.Constant.STOP),
+            None,
+        )
+        verify = model.copy()
+        for segment in plan:
+            verify.integrate_segment(segment)
+            here = segment.end_pressure
+            gf = (
+                gradient.factor(here, first_stop)
+                if first_stop is not None
+                else gradient.gf_low
+            )
+            assert verify.get_ceiling(gf) <= here
+
+    def test_lower_gf_longer_schedule(self):
+        conservative = plan_ascent(
+            loaded_model(40, 25, Gradient(0.3, 0.7)), Pressure.from_depth_m(40), AIR
+        )
+        liberal = plan_ascent(
+            loaded_model(40, 25, Gradient(0.9, 0.9)), Pressure.from_depth_m(40), AIR
+        )
+        assert total_time(conservative) > total_time(liberal)
+
+    def test_deco_gas_shortens_schedule_and_switches_at_stop(self):
+        gases = GasPlan([AIR, EAN50])
+        air_only = plan_ascent(
+            loaded_model(40, 25, Gradient(0.3, 0.7)), Pressure.from_depth_m(40), AIR
+        )
+        with_deco_gas = plan_ascent(
+            loaded_model(40, 25, Gradient(0.3, 0.7)),
+            Pressure.from_depth_m(40),
+            AIR,
+            gas_plan=gases,
+        )
+        assert total_time(with_deco_gas) < total_time(air_only)
+
+        switches = [
+            s for s in with_deco_gas if s.kind is SegmentKind.Constant.GAS_SWITCH
+        ]
+        assert len(switches) == 1
+        assert switches[0].gas == EAN50
+        # Switch must happen where EAN50 is breathable (≤ ~21 m).
+        assert GasPlan.is_breathable(EAN50, switches[0].start_pressure)
+        assert_plan_well_formed(with_deco_gas, Pressure.from_depth_m(40))
+
+    def test_vpm_plan_terminates_and_is_well_formed(self):
+        model = VpmB()
+        p30 = Pressure.from_depth_m(30)
+        model.integrate_segment(DiveSegment(Pressure.surface(), p30, 1.5, AIR))
+        model.integrate_segment(DiveSegment(p30, p30, 12, AIR))
+        plan = plan_ascent(model, p30, AIR)
+        assert_plan_well_formed(plan, p30)
+        assert any(s.kind is SegmentKind.Constant.STOP for s in plan)


### PR DESCRIPTION
## Summary

Steps 4 and 5 of the roadmap, stacked on #4 (merge order: #2 → #3 → #4 → this). Three commits:

**Foundations** — `DiveProfile.iter_samples(interval)` becomes the single sampling authority (steps tile the runtime exactly and never cross segment boundaries, so checkpoints are exact); `BaseDecoModel` gains the checkpointing contract (`set_state`/`copy` abstract, public `get_state`/`integrate`). Also a library fix the planner surfaced: profile *simplicity* now requires matching segment kinds — merging a GAS_SWITCH into a same-gas stop erases semantics.

**Ascent planner** — `plan_ascent(model, start, gas, gas_plan)` is a pure function: clones the model, emits continuous DECO_ASCENT/STOP/GAS_SWITCH segments to the surface. Staged-decompression loop on the configured stop grid; GF models get the gradient interpolated at each target depth anchored at the ascent's deepest stop; gas switches to the richest breathable deco gas on stop arrival. `GasPlan` handles ppO2-window selection. Iteration-capped (`AscentNotConvergingError`) instead of hangable. Known v1 limits, documented: switches at stops only; VPM-B runs on pre-CVA gradients (CVA + Boyle compensation are the planner's next iteration).

**DiveResult** — the agreed result layer: `run(profile, model)` stores state checkpoints at segment boundaries only (O(segments) memory for batch); `state_at`/`ceiling_at`/`model_at(t)` re-integrate at most one partial segment from the nearest checkpoint (exact — Haldane composes, verified against direct integration); `tissue_series(dt)` for plots; `tts(t)` answers "if I ascended now, how long?" by planning a counterfactual ascent from the state at t. Profiles remain pure input; neither the caller's model nor profile is mutated (tested).

`diveplan` now re-exports `DiveProfile`, `DiveResult`, `GasPlan`, `plan_ascent`.

## Testing

427 tests pass (35 new), strict mypy clean, ruff clean. Highlights: sample tiling/boundary exactness, iter_samples ≡ integrate_segment, checkpoint-exactness of `state_at`, plan structural invariants (continuity to surface, stop grid, monotone shallowing, ceiling respected at every waypoint on replay), lower GF ⇒ longer schedule, deco gas ⇒ shorter schedule with exactly one switch at a breathable depth, VPM-B schedules terminate well-formed, TTS grows with bottom time and equals bare ascent time on no-deco dives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)