### PR TITLE
Report layer: consumption, CNS/OTU, rock bottom, TTS variations, formatters

### DIFF
--- a/.claude/codebase-index.md
+++ b/.claude/codebase-index.md
@@ -13,7 +13,7 @@ diveplan — dive planning and decompression calculation library.
   - @property `planning(self) -> _DivePlanningConfig`
   dunders: `__repr__, __str__`
 - const `diveconfig = _ConfigProxy()`
-`__all__ = ['Pressure', 'Gas', 'DiveSegment', 'SegmentKind', 'DiveConfig', 'diveconfig', 'DiveProfile', 'DiveResult', 'GasPlan', 'plan_ascent']`
+`__all__ = ['Pressure', 'Gas', 'DiveSegment', 'SegmentKind', 'DiveConfig', 'diveconfig', 'DiveProfile', 'DiveReport', 'DiveResult', 'GasPlan', 'plan_ascent']`
 
 ## `src/diveplan/core/__init__.py`
 Core value objects and configuration for diveplan.
@@ -31,7 +31,7 @@ diveplan.core.config
 ### class `_DivePlanningConfig` (_SubConfig) — Ascent/descent rates and stop parameters.
   attrs: `ascent_rate: float = Field(default=9.0, gt=0, description='m/min'); descent_rate: float = Field(default=20.0, gt=0, description='m/min'); stop_increment_m: float = Field(default=3.0, gt=0, description='meters between deco stops'); last_stop_m: float = Field(default=3.0, gt=0, description='depth of last deco stop in meters'); min_stop_time_s: int = Field(default=60, gt=0, description='minimum time at each stop in seconds'); sample_rate_s: int = Field(default=1, gt=0, description='integration sample rate in seconds'); default_model: str = Field(default='zhl16c', description='registry name of default deco model')`
 ### class `_GasConfig` (_SubConfig) — Gas planning limits and SAC rates.
-  attrs: `min_ppo2_bar: float = Field(default=0.18, gt=0, description='bar — hypoxia floor'); max_ppo2_bar: float = Field(default=1.4, gt=0, description='bar — working/bottom ppO2 limit'); deco_ppo2_bar: float = Field(default=1.6, gt=0, description='bar — ppO2 limit at deco stops'); max_ppn2_bar: float = Field(default=3.2, gt=0, description='bar — narcosis/ppN2 ceiling'); max_end_m: float = Field(default=30.0, gt=0, description='meters — maximum equivalent narcotic depth'); sac_bottom: float = Field(default=20.0, gt=0, description='L/min — surface air consumption at bottom'); sac_deco: float = Field(default=15.0, gt=0, description='L/min — surface air consumption at deco stops'); gas_switch_minutes: float = Field(default=1.0, ge=0, description='minutes added per gas switch — 0 = instant'); gas_switch_at_stops_only: bool = Field(default=True, description='if True, gas switches only allowed at deco stops')`
+  attrs: `min_ppo2_bar: float = Field(default=0.18, gt=0, description='bar — hypoxia floor'); max_ppo2_bar: float = Field(default=1.4, gt=0, description='bar — working/bottom ppO2 limit'); deco_ppo2_bar: float = Field(default=1.6, gt=0, description='bar — ppO2 limit at deco stops'); max_ppn2_bar: float = Field(default=3.2, gt=0, description='bar — narcosis/ppN2 ceiling'); max_end_m: float = Field(default=30.0, gt=0, description='meters — maximum equivalent narcotic depth'); sac_bottom: float = Field(default=20.0, gt=0, description='L/min — surface air consumption at bottom'); sac_deco: float = Field(default=15.0, gt=0, description='L/min — surface air consumption at deco stops'); sac_factor: float = Field(default=2.0, gt=0, description='stress multiplier on SAC for rock-bottom/emergency planning'); problem_solving_minutes: float = Field(default=1.0, ge=0, description='minutes spent solving a problem at depth (rock bottom)'); gas_switch_minutes: float = Field(default=1.0, ge=0, description='minutes added per gas switch — 0 = instant'); gas_switch_at_stops_only: bool = Field(default=True, description='if True, gas switches only allowed at deco stops')`
 - `_try_load(path: Path | str, source: str, config_cls: type[DiveConfig]) -> DiveConfig | None`  — Attempt to load a DiveConfig from a file. Returns None on any failure.
 - `_load_default_config() -> DiveConfig`  — Resolve the startup default config following the priority chain:
 ### class `DiveConfig` (BaseModel) — Root configuration object.
@@ -232,11 +232,22 @@ core/pressure.py — Pressure value type.
   - @classmethod `from_json(cls, data: Optional[str] = None, path: Optional[str] = None) -> DiveProfile`  — Deserialize from a JSON string or file path (see :meth:`from_dict`).
 
 ## `src/diveplan/dive/dive_report.py`
-(empty stub)
+Dive report: everything about a computed dive, ready for presentation.
+`__all__ = ['DiveReport', 'ReportRow']`
+### class `ReportRow` (NamedTuple) — One schedule line: a segment with its cumulative runtime at the end.
+  attrs: `runtime: timedelta; start_depth_m: float; end_depth_m: float; duration: timedelta; gas: Gas; kind: str`
+### class `DiveReport` — Immutable summary of a computed dive.
+  `__slots__ = ('profile', 'model_name', 'rows', 'runtime', 'max_depth', 'consumption_l', 'cns', 'otus', 'rock_bottom_l', 'tts_variations')`
+  - `__init__(self, *, profile: DiveProfile, model_name: str, rows: tuple[ReportRow, ...], runtime: timedelta, max_depth: Pressure, consumption_l: tuple[tuple[Gas, float], ...], cns: float, otus: float, rock_bottom_l: float, tts_variations: Optional[TtsVariations])`
+  - @classmethod `from_result(cls, result: DiveResult[DecoState], *, gas_plan: Optional[GasPlan] = None, tts_variations: Optional[TtsVariations] = None) -> 'DiveReport'`  — Assemble a report from a dive result.
+  attrs: `profile: DiveProfile; model_name: str; rows: tuple[ReportRow, ...]; runtime: timedelta; max_depth: Pressure; consumption_l: tuple[tuple[Gas, float], ...]; cns: float; otus: float; rock_bottom_l: float; tts_variations: Optional[TtsVariations]`
+  dunders: `__repr__`
 
 ## `src/diveplan/dive/dive_result.py`
 Result layer: a deco model run over a profile, queryable by time.
-`__all__ = ['DiveResult']`
+`__all__ = ['DiveResult', 'TtsVariations']`
+### class `TtsVariations` (NamedTuple) — Sensitivity of the time-to-surface to small plan changes — the
+  attrs: `per_meter: timedelta; per_minute: timedelta`
 ### class `DiveResult[StateT: DecoState]` — A deco model's run over a profile: checkpoints + time queries.
   `__slots__ = ('_profile', '_model', '_checkpoints')`
   - `__init__(self, profile: DiveProfile, model: BaseDecoModel[StateT], checkpoints: tuple[StateT, ...])`
@@ -249,11 +260,54 @@ Result layer: a deco model run over a profile, queryable by time.
   - `ceiling_at(self, t: timedelta | float) -> Pressure`  — Deco ceiling at runtime `t`.
   - `tissue_series(self, interval: timedelta | float) -> Iterator[tuple[timedelta, StateT]]`  — Yield (time, state) at each sample step — for tissue plots.
   - `tts(self, t: timedelta | float, gas_plan: GasPlan | None = None) -> timedelta`  — Time-to-surface at runtime `t`: the duration of an ascent planned
+  - `tts_variations(self, gas_plan: GasPlan | None = None) -> TtsVariations`  — Extra time-to-surface per +1 m on the final segment and per +1 min
   - `_unique_gases(self) -> list[Gas]`
+  - @property `model_name(self) -> str`  — Registry name of the model this result was computed with.
   dunders: `__repr__`
+- `_ascent_duration(model: BaseDecoModel[Any], start_pressure: Pressure, gas: Gas, gas_plan: GasPlan, clock_offset: timedelta) -> timedelta`
 
 ## `src/diveplan/dive/formatters/__init__.py`
-(empty stub)
+Report formatters: turn a DiveReport into an output document.
+`__all__ = ['BaseFormatter']`
+### class `BaseFormatter` (ABC) — Base class for all report formatters.
+  - @abstract `format(self, report: DiveReport) -> str`  — Render the report as a string in this formatter's output format.
+  attrs: `NAME: ClassVar[str]`
+
+## `src/diveplan/dive/formatters/console.py`
+Plain-text report formatter for terminals and logs.
+`__all__ = ['ConsoleFormatter']`
+- `_minutes(td: timedelta) -> str`
+- `_describe(row: ReportRow) -> str`
+### class `ConsoleFormatter` (BaseFormatter) — Human-readable dive plan table with a summary block.
+  - `format(self, report: DiveReport) -> str`
+  attrs: `NAME = 'console'`
+
+## `src/diveplan/dive/formatters/json.py`
+JSON report formatter — machine-readable dive plan document.
+`__all__ = ['JsonFormatter']`
+### class `JsonFormatter` (BaseFormatter) — Serialize the whole report to a JSON document.
+  - `__init__(self, *, indent: int | None = 2)`
+  - `format(self, report: DiveReport) -> str`
+  attrs: `NAME = 'json'`
+
+## `src/diveplan/dive/formatters/subsurface.py`
+Subsurface dive-log XML formatter (experimental).
+`__all__ = ['SubsurfaceXmlFormatter']`
+- `_mmss(td: timedelta) -> str`
+- `_depth(metres: float) -> str`
+- `_gas_attrs(gas: Gas) -> dict[str, str]`
+### class `SubsurfaceXmlFormatter` (BaseFormatter) — Render the report as a Subsurface dive-log XML document.
+  - `__init__(self, *, planned_at: datetime | None = None)`
+  - `format(self, report: DiveReport) -> str`
+  attrs: `NAME = 'subsurface'; SAMPLE_STEP = timedelta(seconds=10)`
+
+## `src/diveplan/dive/oxygen.py`
+Oxygen-exposure tracking: NOAA CNS clock and REPEX OTUs.
+`__all__ = ['cns_percent', 'otu', 'NOAA_CNS_LIMITS']`
+- `_cns_limit_minutes(ppo2_bar: float) -> float | None`  — NOAA limit at `ppo2_bar`, linearly interpolated; None below the floor.
+- `_iter_ppo2(segments: Iterable[DiveSegment], step: timedelta) -> Iterable[tuple[float, float]]`  — Yield (minutes, ppO2 bar) exposures: one per constant segment, midpoint
+- `cns_percent(segments: Iterable[DiveSegment], *, step: timedelta = timedelta(seconds=10)) -> float`  — CNS oxygen-toxicity clock over `segments`, in percent (100 = NOAA limit).
+- `otu(segments: Iterable[DiveSegment], *, step: timedelta = timedelta(seconds=10)) -> float`  — Pulmonary oxygen-toxicity units (REPEX) accumulated over `segments`.
 
 ## `src/diveplan/models/__init__.py`
 (empty stub)
@@ -381,11 +435,11 @@ Ascent planner: compute the decompression schedule from a model state.
 ### class `AscentNotConvergingError` (RuntimeError) — The stop loop failed to clear the next target within the iteration cap.
 - `_ceiling(model: BaseDecoModel[Any], target: Pressure, first_stop: Optional[Pressure]) -> Pressure`  — Model ceiling for an ascent-to-`target` test.
 - `_next_targets(current: Pressure) -> list[Pressure]`  — Candidate ascent targets from shallowest to deepest: the surface, then
-- `plan_ascent(model: BaseDecoModel[Any], start_pressure: Pressure, gas: Gas, gas_plan: Optional[GasPlan] = None) -> list[DiveSegment]`  — Plan the decompression ascent from the given position and model state.
+- `plan_ascent(model: BaseDecoModel[Any], start_pressure: Pressure, gas: Gas, gas_plan: Optional[GasPlan] = None, clock_offset: timedelta | float = timedelta(0)) -> list[DiveSegment]`  — Plan the decompression ascent from the given position and model state.
 
 ## `src/diveplan/planning/gas_plan.py`
-Gas plan: the set of gases carried on a dive, and which to breathe when.
-`__all__ = ['GasPlan']`
+Gas plan: carried gases, selection, consumption, and reserve planning.
+`__all__ = ['GasPlan', 'gas_consumption', 'rock_bottom']`
 ### class `GasPlan` — An ordered collection of carried gases with depth-based selection.
   `__slots__ = ('_gases',)`
   - `__init__(self, gases: Iterable[Gas])`
@@ -393,6 +447,8 @@ Gas plan: the set of gases carried on a dive, and which to breathe when.
   - @staticmethod `is_breathable(gas: Gas, pressure: Pressure) -> bool`  — Whether `gas` is within the configured deco ppO2 window here.
   - `best_gas_at(self, pressure: Pressure) -> Optional[Gas]`  — Richest breathable gas at `pressure`, or None if none qualifies.
   dunders: `__repr__`
+- `gas_consumption(segments: Iterable[DiveSegment]) -> dict[Gas, float]`  — Surface litres of each gas consumed over `segments`.
+- `rock_bottom(depth: Pressure | str | float, *, divers: int = 2) -> float`  — Minimum gas reserve (surface litres) at `depth` for an emergency.
 
 ## `src/diveplan/registry.py`
 ### class `PluginNotFoundError` (KeyError)
@@ -427,6 +483,7 @@ Gas plan: the set of gases carried on a dive, and which to breathe when.
 - `test_dive_result.py` (20 tests) — TestIterSamples, TestDiveResultRun, TestDiveResultQueries
 - `test_dive_segment.py` (59 tests) — TestDiveSegmentConstruction, TestDiveSegmentProperties, TestDiveSegmentInterpolation, TestDiveSegmentSplitting, TestDiveSegmentMerging, TestDiveSegmentContinuity, TestDiveSegmentIteration, TestDiveSegmentMagicMethods, TestDiveSegmentImmutability, TestDiveSegmentSerialization
 - `test_gas.py` (61 tests) — TestRawConstruction, TestNamedConstructors, TestFromName, TestPartialPressures, TestMod, TestEnd, TestBestMix, TestEqualityAndHash, TestStringRepresentation
-- `test_planning.py` (15 tests) — TestGasPlan, TestPlanAscentNoDeco, TestPlanAscentDeco
+- `test_planning.py` (16 tests) — TestGasPlan, TestPlanAscentNoDeco, TestPlanAscentDeco
 - `test_pressure.py` (70 tests) — TestConstruction, TestProperties, TestAltConstructorsAndProperties, TestStringParsing, TestImmutability, TestAddition, TestSubtraction, TestMultiplication, TestDivision, TestOrdering, TestHashing, TestDisplay
+- `test_report.py` (21 tests) — TestGasConsumption, TestRockBottom, TestOxygenExposure, TestTtsVariations, TestDiveReport
 - `test_vpm.py` (23 tests) — TestBubbleMechanics, TestVpmBModel, TestVpmBRegistry

--- a/.claude/codebase-index.md
+++ b/.claude/codebase-index.md
@@ -13,7 +13,7 @@ diveplan — dive planning and decompression calculation library.
   - @property `planning(self) -> _DivePlanningConfig`
   dunders: `__repr__, __str__`
 - const `diveconfig = _ConfigProxy()`
-`__all__ = ['Pressure', 'Gas', 'DiveSegment', 'SegmentKind', 'DiveConfig', 'diveconfig', 'DiveProfile', 'DiveReport', 'DiveResult', 'GasPlan', 'plan_ascent']`
+`__all__ = ['Pressure', 'Gas', 'DiveSegment', 'SegmentKind', 'DiveConfig', 'diveconfig', 'Dive', 'DiveProfile', 'DiveReport', 'GasPlan', 'plan_ascent']`
 
 ## `src/diveplan/core/__init__.py`
 Core value objects and configuration for diveplan.
@@ -141,6 +141,32 @@ core/pressure.py — Pressure value type.
 ## `src/diveplan/dive/__init__.py`
 (empty stub)
 
+## `src/diveplan/dive/dive.py`
+Dive: a deco model run over a profile, queryable and extendable.
+`__all__ = ['Dive', 'TtsVariations']`
+### class `TtsVariations` (NamedTuple) — Sensitivity of the time-to-surface to small plan changes — the
+  attrs: `per_meter: timedelta; per_minute: timedelta`
+### class `Dive[StateT: DecoState]` — A deco model's run over a profile — complete or still in progress.
+  `__slots__ = ('_profile', '_model', '_checkpoints')`
+  - `__init__(self, profile: DiveProfile, model: BaseDecoModel[StateT], checkpoints: tuple[StateT, ...])`
+  - @classmethod `run(cls, profile: DiveProfile, model: BaseDecoModel[StateT]) -> 'Dive[StateT]'`  — Integrate `model` over `profile` and capture boundary checkpoints.
+  - @property `profile(self) -> DiveProfile`  — The dive profile this dive was computed from (own copy).
+  - @property `checkpoints(self) -> tuple[StateT, ...]`  — Model states at segment boundaries; ``[0]`` is the pre-dive state,
+  - @property `final_state(self) -> StateT`  — Model state at the end of the profile.
+  - `model_at(self, t: timedelta | float) -> BaseDecoModel[StateT]`  — Independent model instance positioned at runtime `t`.
+  - `state_at(self, t: timedelta | float) -> StateT`  — Model state at runtime `t` (minutes or timedelta).
+  - `ceiling_at(self, t: timedelta | float) -> Pressure`  — Deco ceiling at runtime `t`.
+  - `tissue_series(self, interval: timedelta | float) -> Iterator[tuple[timedelta, StateT]]`  — Yield (time, state) at each sample step — for tissue plots.
+  - `tts(self, t: timedelta | float, gas_plan: GasPlan | None = None) -> timedelta`  — Time-to-surface at runtime `t`: the duration of an ascent planned
+  - `plan_ascent(self, gas_plan: GasPlan | None = None) -> list[DiveSegment]`  — Deco schedule from the dive's current end to the surface.
+  - `extend(self, segments: list[DiveSegment]) -> 'Dive[StateT]'`  — New Dive with `segments` appended and integrated.
+  - `with_ascent(self, gas_plan: GasPlan | None = None) -> 'Dive[StateT]'`  — New Dive completed with its planned deco ascent —
+  - `tts_variations(self, gas_plan: GasPlan | None = None) -> TtsVariations`  — Extra time-to-surface per +1 m on the final segment and per +1 min
+  - `_unique_gases(self) -> list[Gas]`
+  - @property `model_name(self) -> str`  — Registry name of the model this result was computed with.
+  dunders: `__repr__`
+- `_ascent_duration(model: BaseDecoModel[Any], start_pressure: Pressure, gas: Gas, gas_plan: GasPlan, clock_offset: timedelta) -> timedelta`
+
 ## `src/diveplan/dive/dive_profile.py`
 `__all__ = ('DiveProfile', 'ProfileSample', 'ProfileValidationError', 'ProfileContinuityError', 'ProfileSimplicityError', 'ProfileStartEndError', 'ProfileDepthContinuityError', 'ProfileGasContinuityError', 'ProfileEmptyError', 'ProfileTooShortError', 'ProfileBuilderPolicy')`
 ### class `ProfileValidationError` (ValueError) — Base descriptor for a dive profile validation problem.
@@ -239,32 +265,9 @@ Dive report: everything about a computed dive, ready for presentation.
 ### class `DiveReport` — Immutable summary of a computed dive.
   `__slots__ = ('profile', 'model_name', 'rows', 'runtime', 'max_depth', 'consumption_l', 'cns', 'otus', 'rock_bottom_l', 'tts_variations')`
   - `__init__(self, *, profile: DiveProfile, model_name: str, rows: tuple[ReportRow, ...], runtime: timedelta, max_depth: Pressure, consumption_l: tuple[tuple[Gas, float], ...], cns: float, otus: float, rock_bottom_l: float, tts_variations: Optional[TtsVariations])`
-  - @classmethod `from_result(cls, result: DiveResult[DecoState], *, gas_plan: Optional[GasPlan] = None, tts_variations: Optional[TtsVariations] = None) -> 'DiveReport'`  — Assemble a report from a dive result.
+  - @classmethod `from_dive(cls, dive: Dive[DecoState], *, gas_plan: Optional[GasPlan] = None, tts_variations: Optional[TtsVariations] = None) -> 'DiveReport'`  — Assemble a report from a computed dive.
   attrs: `profile: DiveProfile; model_name: str; rows: tuple[ReportRow, ...]; runtime: timedelta; max_depth: Pressure; consumption_l: tuple[tuple[Gas, float], ...]; cns: float; otus: float; rock_bottom_l: float; tts_variations: Optional[TtsVariations]`
   dunders: `__repr__`
-
-## `src/diveplan/dive/dive_result.py`
-Result layer: a deco model run over a profile, queryable by time.
-`__all__ = ['DiveResult', 'TtsVariations']`
-### class `TtsVariations` (NamedTuple) — Sensitivity of the time-to-surface to small plan changes — the
-  attrs: `per_meter: timedelta; per_minute: timedelta`
-### class `DiveResult[StateT: DecoState]` — A deco model's run over a profile: checkpoints + time queries.
-  `__slots__ = ('_profile', '_model', '_checkpoints')`
-  - `__init__(self, profile: DiveProfile, model: BaseDecoModel[StateT], checkpoints: tuple[StateT, ...])`
-  - @classmethod `run(cls, profile: DiveProfile, model: BaseDecoModel[StateT]) -> 'DiveResult[StateT]'`  — Integrate `model` over `profile` and capture boundary checkpoints.
-  - @property `profile(self) -> DiveProfile`  — The dive profile this result was computed from (own copy).
-  - @property `checkpoints(self) -> tuple[StateT, ...]`  — Model states at segment boundaries; ``[0]`` is the pre-dive state,
-  - @property `final_state(self) -> StateT`  — Model state at the end of the profile.
-  - `model_at(self, t: timedelta | float) -> BaseDecoModel[StateT]`  — Independent model instance positioned at runtime `t`.
-  - `state_at(self, t: timedelta | float) -> StateT`  — Model state at runtime `t` (minutes or timedelta).
-  - `ceiling_at(self, t: timedelta | float) -> Pressure`  — Deco ceiling at runtime `t`.
-  - `tissue_series(self, interval: timedelta | float) -> Iterator[tuple[timedelta, StateT]]`  — Yield (time, state) at each sample step — for tissue plots.
-  - `tts(self, t: timedelta | float, gas_plan: GasPlan | None = None) -> timedelta`  — Time-to-surface at runtime `t`: the duration of an ascent planned
-  - `tts_variations(self, gas_plan: GasPlan | None = None) -> TtsVariations`  — Extra time-to-surface per +1 m on the final segment and per +1 min
-  - `_unique_gases(self) -> list[Gas]`
-  - @property `model_name(self) -> str`  — Registry name of the model this result was computed with.
-  dunders: `__repr__`
-- `_ascent_duration(model: BaseDecoModel[Any], start_pressure: Pressure, gas: Gas, gas_plan: GasPlan, clock_offset: timedelta) -> timedelta`
 
 ## `src/diveplan/dive/formatters/__init__.py`
 Report formatters: turn a DiveReport into an output document.
@@ -277,8 +280,9 @@ Report formatters: turn a DiveReport into an output document.
 Plain-text report formatter for terminals and logs.
 `__all__ = ['ConsoleFormatter']`
 - `_minutes(td: timedelta) -> str`
-- `_describe(row: ReportRow) -> str`
+- `_row_line(row: ReportRow) -> str`
 ### class `ConsoleFormatter` (BaseFormatter) — Human-readable dive plan table with a summary block.
+  - @staticmethod `format_schedule(segments: Iterable[DiveSegment]) -> str`  — Render any segment sequence (a profile's or an ascent plan) as a
   - `format(self, report: DiveReport) -> str`
   attrs: `NAME = 'console'`
 
@@ -341,6 +345,7 @@ Shared Bühlmann machinery: gradient factors and Haldane tissue compartments.
 ### class `Gradient` — A gradient-factor pair (Baker GF low/high), as fractions.
   `__slots__ = ('gf_low', 'gf_high')`
   - `__init__(self, gf_low: float, gf_high: float)`
+  - @classmethod `from_str(cls, s: str) -> 'Gradient'`  — Parse the usual GF notation: ``"30/70"``, ``"GF 30/70"``, ``"85/85"``.
   - `factor(self, pressure: Pressure, first_stop_pressure: Pressure) -> float`  — Gradient factor applicable at ``pressure``.
   attrs: `gf_low: float; gf_high: float`
   dunders: `__eq__, __hash__, __repr__, __str__`
@@ -367,7 +372,7 @@ Generic Bühlmann decompression engine.
   dunders: `__delattr__, __eq__, __hash__, __repr__, __setattr__`
 ### class `BuhlmannModel` (BaseDecoModel[BuhlmannState]) — Bühlmann algorithm over a subclass-supplied coefficient table.
   `__slots__ = ('gradient', '_compartments')`
-  - `__init__(self, gradient: Gradient | None = None)`
+  - `__init__(self, gradient: Gradient | str | None = None)`
   - @property `compartment_count(self) -> int`  — Number of tissue compartments in this model's table.
   - `_integrate_model(self, pressure: Pressure, gas: Gas, dt: timedelta) -> None`
   - `_get_deco_state(self) -> BuhlmannState`
@@ -477,10 +482,10 @@ Gas plan: carried gases, selection, consumption, and reserve planning.
 
 # Tests (tests/)
 - `conftest.py` (0 tests)
-- `test_buhlmann.py` (44 tests) — TestGradient, TestCompartmentState, TestCompartmentIntegration, TestCompartmentToleratedPressure, TestZHL16CTables, TestZHL16CModel, MiniBuhlmann, TestBuhlmannFamily, TestZHL16CRegistry
+- `test_buhlmann.py` (47 tests) — TestGradient, TestCompartmentState, TestCompartmentIntegration, TestCompartmentToleratedPressure, TestZHL16CTables, TestZHL16CModel, MiniBuhlmann, TestBuhlmannFamily, TestZHL16CRegistry
 - `test_config.py` (45 tests) — TestSubConfigBase, TestPhysicsConfig, TestGasConfig, TestDivePlanningConfig, TestDiveConfigStructure, TestGlobalDefault, TestContextManager, TestDefaultConfigLoading, TestSerialization
+- `test_dive.py` (24 tests) — TestIterSamples, TestDiveRun, TestDiveQueries, TestDiveContinuation
 - `test_dive_profile.py` (74 tests) — TestDiveProfileBuilder, TestDiveProfileValidation, TestDiveProfileFixes, TestDiveProfileTimeline, TestDiveProfileFluentBuilders, TestDiveProfileSerialization
-- `test_dive_result.py` (20 tests) — TestIterSamples, TestDiveResultRun, TestDiveResultQueries
 - `test_dive_segment.py` (59 tests) — TestDiveSegmentConstruction, TestDiveSegmentProperties, TestDiveSegmentInterpolation, TestDiveSegmentSplitting, TestDiveSegmentMerging, TestDiveSegmentContinuity, TestDiveSegmentIteration, TestDiveSegmentMagicMethods, TestDiveSegmentImmutability, TestDiveSegmentSerialization
 - `test_gas.py` (61 tests) — TestRawConstruction, TestNamedConstructors, TestFromName, TestPartialPressures, TestMod, TestEnd, TestBestMix, TestEqualityAndHash, TestStringRepresentation
 - `test_planning.py` (18 tests) — TestGasPlan, TestPlanAscentNoDeco, TestPlanAscentDeco

--- a/.claude/codebase-index.md
+++ b/.claude/codebase-index.md
@@ -435,14 +435,14 @@ Ascent planner: compute the decompression schedule from a model state.
 ### class `AscentNotConvergingError` (RuntimeError) — The stop loop failed to clear the next target within the iteration cap.
 - `_ceiling(model: BaseDecoModel[Any], target: Pressure, first_stop: Optional[Pressure]) -> Pressure`  — Model ceiling for an ascent-to-`target` test.
 - `_next_targets(current: Pressure) -> list[Pressure]`  — Candidate ascent targets from shallowest to deepest: the surface, then
-- `plan_ascent(model: BaseDecoModel[Any], start_pressure: Pressure, gas: Gas, gas_plan: Optional[GasPlan] = None, clock_offset: timedelta | float = timedelta(0)) -> list[DiveSegment]`  — Plan the decompression ascent from the given position and model state.
+- `plan_ascent(model: BaseDecoModel[Any], start_pressure: Pressure | str | float, gas: Gas | str, gas_plan: Optional[GasPlan] = None, clock_offset: timedelta | float = timedelta(0)) -> list[DiveSegment]`  — Plan the decompression ascent from the given position and model state.
 
 ## `src/diveplan/planning/gas_plan.py`
 Gas plan: carried gases, selection, consumption, and reserve planning.
 `__all__ = ['GasPlan', 'gas_consumption', 'rock_bottom']`
 ### class `GasPlan` — An ordered collection of carried gases with depth-based selection.
   `__slots__ = ('_gases',)`
-  - `__init__(self, gases: Iterable[Gas])`
+  - `__init__(self, gases: Iterable[Gas | str])`
   - @property `gases(self) -> tuple[Gas, ...]`  — The carried gases (duplicates removed, insertion order).
   - @staticmethod `is_breathable(gas: Gas, pressure: Pressure) -> bool`  — Whether `gas` is within the configured deco ppO2 window here.
   - `best_gas_at(self, pressure: Pressure) -> Optional[Gas]`  — Richest breathable gas at `pressure`, or None if none qualifies.
@@ -483,7 +483,7 @@ Gas plan: carried gases, selection, consumption, and reserve planning.
 - `test_dive_result.py` (20 tests) — TestIterSamples, TestDiveResultRun, TestDiveResultQueries
 - `test_dive_segment.py` (59 tests) — TestDiveSegmentConstruction, TestDiveSegmentProperties, TestDiveSegmentInterpolation, TestDiveSegmentSplitting, TestDiveSegmentMerging, TestDiveSegmentContinuity, TestDiveSegmentIteration, TestDiveSegmentMagicMethods, TestDiveSegmentImmutability, TestDiveSegmentSerialization
 - `test_gas.py` (61 tests) — TestRawConstruction, TestNamedConstructors, TestFromName, TestPartialPressures, TestMod, TestEnd, TestBestMix, TestEqualityAndHash, TestStringRepresentation
-- `test_planning.py` (16 tests) — TestGasPlan, TestPlanAscentNoDeco, TestPlanAscentDeco
+- `test_planning.py` (18 tests) — TestGasPlan, TestPlanAscentNoDeco, TestPlanAscentDeco
 - `test_pressure.py` (70 tests) — TestConstruction, TestProperties, TestAltConstructorsAndProperties, TestStringParsing, TestImmutability, TestAddition, TestSubtraction, TestMultiplication, TestDivision, TestOrdering, TestHashing, TestDisplay
 - `test_report.py` (21 tests) — TestGasConsumption, TestRockBottom, TestOxygenExposure, TestTtsVariations, TestDiveReport
 - `test_vpm.py` (23 tests) — TestBubbleMechanics, TestVpmBModel, TestVpmBRegistry

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,8 +38,10 @@ Layering (imports flow strictly downward; `core/` never imports from upper layer
 core/          Pressure, Gas, DiveSegment, DiveConfig — value objects + config
 dive/dive_profile.py  DiveProfile (builder/validation/timeline/iter_samples) — core only
 models/        deco models (BaseDecoModel[StateT], Bühlmann family, VPM-B)
-planning/      plan_ascent + GasPlan — consumes models
+planning/      plan_ascent, GasPlan, gas_consumption, rock_bottom — consumes models
 dive/dive_result.py   DiveResult — top of the stack (profile + models + planning)
+dive/dive_report.py   DiveReport (pure data) + dive/formatters/ (console, json, subsurface XML)
+dive/oxygen.py CNS (NOAA table) and OTU accumulation over segments
 registry.py    entry-point plugin discovery for deco models
 ```
 
@@ -86,9 +88,13 @@ Model families: `BuhlmannModel` (models/buhlmann/model.py) is the whole Bühlman
 
 Plugin discovery: entry-point group **`diveplan.deco_models`** (single source of truth: `_ENTRY_POINT_GROUP` in `registry.py`). The registry eagerly loads *every* entry point in the group on first access, so never register an entry point in `pyproject.toml` before its module exists — one dangling reference breaks all model lookups. The `zhl16c` and formatter entry points are commented out in `pyproject.toml` until their modules land; `DiveConfig.planning.default_model` defaults to `"zhl16c"`, so uncomment the entry point in the same PR that adds `zhl16.py`. `registry.register_model()` is the manual escape hatch for tests.
 
+### Report layer
+
+`DiveReport.from_result(result)` is pure data: schedule rows + gas consumption (surface litres, exact per linear segment), CNS/OTU (`dive/oxygen.py`), rock bottom at max depth, and optional `TtsVariations` (the "+1 m / +1 min" figures — compute them on the *bottom* result via `DiveResult.tts_variations()`, they are meaningless on a full dive with deco). Formatters (`BaseFormatter.format(report) -> str`) are presentation-only; entry-point group `diveplan.formatters` (console/json/subsurface). Consumption/CNS/OTU take `Iterable[DiveSegment]`, so they work on plans as well as profiles.
+
 ### Known state / gotchas
 
-- `dive/dive_report.py` and `dive/formatters/` are empty stubs (report layer not started).
+- The Subsurface XML formatter is experimental — validated structurally, not yet round-tripped through a real Subsurface import.
 - VPM-B CVA + Boyle compensation pending in the planner (see above).
 - `diveplan_roadmap.md` predates implementation and drifts from the code in places (e.g. `DiveStep`/`AbstractDecoModel` naming — the code's `DiveSegment`/`BaseDecoModel` won); trust the code.
 - `__init__.py` re-exports core types, `DiveProfile`, `DiveResult`, `GasPlan`, `plan_ascent`, and a `diveconfig` proxy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ core/          Pressure, Gas, DiveSegment, DiveConfig — value objects + config
 dive/dive_profile.py  DiveProfile (builder/validation/timeline/iter_samples) — core only
 models/        deco models (BaseDecoModel[StateT], Bühlmann family, VPM-B)
 planning/      plan_ascent, GasPlan, gas_consumption, rock_bottom — consumes models
-dive/dive_result.py   DiveResult — top of the stack (profile + models + planning)
+dive/dive.py   Dive — top of the stack (profile + models + planning)
 dive/dive_report.py   DiveReport (pure data) + dive/formatters/ (console, json, subsurface XML)
 dive/oxygen.py CNS (NOAA table) and OTU accumulation over segments
 registry.py    entry-point plugin discovery for deco models
@@ -64,9 +64,9 @@ Tests: `tests/conftest.py` has an autouse fixture pinning a fresh factory-defaul
 
 ### DiveProfile: plan is input, results are output
 
-A profile is pure geometry (list of segments). Do **not** hang model results (tissue states, ceilings, TTS) on segments or the profile — results live in `DiveResult` (`dive/dive_result.py`) so one profile can be run under multiple models/GFs and compared. This is a deliberate, agreed design constraint.
+A profile is pure geometry (list of segments). Do **not** hang model results (tissue states, ceilings, TTS) on segments or the profile — results live in `Dive` (`dive/dive.py`) so one profile can be run under multiple models/GFs and compared. This is a deliberate, agreed design constraint.
 
-`DiveResult.run(profile, model)` copies the model, integrates, and stores **state checkpoints at segment boundaries only** (O(segments) memory for batch). Time queries (`state_at`, `ceiling_at`, `model_at`, `tts(t)`) re-integrate at most one partial segment from the nearest checkpoint — exact, because Haldane integration composes. `tissue_series(dt)` reproduces checkpoints exactly only when sampled at the model's own rate (rectangle rule). `DiveProfile.iter_samples(interval)` is the single sampling authority: steps never cross segment boundaries, the last step of a segment is shortened, zero-duration switches yield no step.
+`Dive.run(profile, model)` copies the model, integrates, and stores **state checkpoints at segment boundaries only** (O(segments) memory for batch). Time queries (`state_at`, `ceiling_at`, `model_at`, `tts(t)`) re-integrate at most one partial segment from the nearest checkpoint — exact, because Haldane integration composes. `tissue_series(dt)` reproduces checkpoints exactly only when sampled at the model's own rate (rectangle rule). `DiveProfile.iter_samples(interval)` is the single sampling authority: steps never cross segment boundaries, the last step of a segment is shortened, zero-duration switches yield no step.
 
 Key mechanics spread across `dive/dive_profile.py`:
 
@@ -90,11 +90,11 @@ Plugin discovery: entry-point group **`diveplan.deco_models`** (single source of
 
 ### Report layer
 
-`DiveReport.from_result(result)` is pure data: schedule rows + gas consumption (surface litres, exact per linear segment), CNS/OTU (`dive/oxygen.py`), rock bottom at max depth, and optional `TtsVariations` (the "+1 m / +1 min" figures — compute them on the *bottom* result via `DiveResult.tts_variations()`, they are meaningless on a full dive with deco). Formatters (`BaseFormatter.format(report) -> str`) are presentation-only; entry-point group `diveplan.formatters` (console/json/subsurface). Consumption/CNS/OTU take `Iterable[DiveSegment]`, so they work on plans as well as profiles.
+`DiveReport.from_dive(dive)` is pure data: schedule rows + gas consumption (surface litres, exact per linear segment), CNS/OTU (`dive/oxygen.py`), rock bottom at max depth, and optional `TtsVariations` (the "+1 m / +1 min" figures — compute them on the *bottom* dive via `Dive.tts_variations()`, they are meaningless on a full dive with deco). Formatters (`BaseFormatter.format(report) -> str`) are presentation-only; entry-point group `diveplan.formatters` (console/json/subsurface). Consumption/CNS/OTU take `Iterable[DiveSegment]`, so they work on plans as well as profiles.
 
 ### Known state / gotchas
 
 - The Subsurface XML formatter is experimental — validated structurally, not yet round-tripped through a real Subsurface import.
 - VPM-B CVA + Boyle compensation pending in the planner (see above).
 - `diveplan_roadmap.md` predates implementation and drifts from the code in places (e.g. `DiveStep`/`AbstractDecoModel` naming — the code's `DiveSegment`/`BaseDecoModel` won); trust the code.
-- `__init__.py` re-exports core types, `DiveProfile`, `DiveResult`, `GasPlan`, `plan_ascent`, and a `diveconfig` proxy.
+- `__init__.py` re-exports core types, `Dive`, `DiveProfile`, `GasPlan`, `plan_ascent`, and a `diveconfig` proxy.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Early development. The **core layer is implemented and tested**:
 | `DiveProfile` — builder, validation & repair, timeline | ✅ |
 | Plugin registry (entry-point deco-model discovery) | ✅ |
 | Deco models — Bühlmann ZHL-16C (GF), VPM-B (pre-CVA) | ✅ |
-| `DiveResult` — checkpoints, `state_at`/`ceiling_at`/`tts(t)` | ✅ |
+| `Dive` — checkpoints, `state_at`/`ceiling_at`/`tts(t)`, `with_ascent` | ✅ |
 | Ascent planner (`plan_ascent`) + `GasPlan` | ✅ |
 | VPM-B critical-volume/Boyle stage, reports, formatters | 🚧 in progress |
 
@@ -110,18 +110,23 @@ profile.to_json(path="dive.json")
 restored = DiveProfile.from_json(path="dive.json")
 ```
 
-Running a deco model over the profile and querying the result:
+Running a deco model over the profile — a `Dive` can be in progress (just
+the bottom phase) and completed with its planned ascent:
 
 ```python
-from diveplan import DiveResult
-from diveplan.models.buhlmann.common import Gradient
+from diveplan import Dive
 from diveplan.models.buhlmann.zhl16 import ZHL16C
 
-result = DiveResult.run(profile, ZHL16C(gradient=Gradient(0.3, 0.7)))
-result.ceiling_at(23).depth_m   # deco ceiling 23 minutes into the dive
-result.tts(23)                  # time-to-surface if ascending right now
-for t, state in result.tissue_series(1):   # tissue loading, 1-min samples
+bottom = DiveProfile().descend_to("40 m").stay(25)
+dive = Dive.run(bottom, ZHL16C(gradient="30/70"))
+
+dive.ceiling_at(23).depth_m   # deco ceiling 23 minutes into the dive
+dive.tts(23)                  # time-to-surface if ascending right now
+for t, state in dive.tissue_series(1):   # tissue loading, 1-min samples
     ...
+
+full = dive.with_ascent()     # new Dive completed with the deco schedule
+full.profile.runtime          # total runtime including stops
 ```
 
 Segments can still be added explicitly (`add_segment`, `insert_segment_at_index`,

--- a/examples/complete_dive_plan.py
+++ b/examples/complete_dive_plan.py
@@ -1,13 +1,13 @@
-"""Complete diveplan walkthrough — plan a 40 m trimix-free deco dive on air
-with an EAN50 deco gas, end to end.
+"""Complete diveplan walkthrough — plan a 40 m deco dive on air with an
+EAN50 deco gas, end to end.
 
 Run from the repo root:
 
     uv run python examples/complete_dive_plan.py
 
 Covers: configuration, gases, fluent profile building, running deco models,
-result queries (ceiling, TTS, tissue loading), ascent planning, model
-comparison, and JSON serialization.
+dive queries (ceiling, TTS, tissue loading), ascent planning, model
+comparison, serialization, and reporting.
 
 DO NOT USE FOR REAL-WORLD DIVE PLANNING — experimental software.
 """
@@ -15,37 +15,26 @@ DO NOT USE FOR REAL-WORLD DIVE PLANNING — experimental software.
 from datetime import timedelta
 
 from diveplan import (
+    Dive,
     DiveConfig,
     DiveProfile,
-    DiveResult,
+    DiveReport,
     Gas,
     GasPlan,
     Pressure,
-    plan_ascent,
 )
-from diveplan.core.dive_segment import DiveSegment, SegmentKind
-from diveplan.models.buhlmann.common import Gradient
+from diveplan.core.dive_segment import SegmentKind
+from diveplan.dive.formatters import (
+    ConsoleFormatter,
+    JsonFormatter,
+    SubsurfaceXmlFormatter,
+)
 from diveplan.models.buhlmann.zhl16 import ZHL16C
 from diveplan.models.vpm.model import VpmB
 
 
 def minutes(td: timedelta) -> str:
     return f"{td.total_seconds() / 60:5.1f} min"
-
-
-def describe(segment: DiveSegment, runtime: timedelta) -> str:
-    depth_from = segment.start_pressure.depth_m
-    depth_to = segment.end_pressure.depth_m
-    if segment.kind is SegmentKind.Constant.GAS_SWITCH:
-        what = f"switch to {segment.gas}"
-    elif depth_from == depth_to:
-        what = f"hold {depth_from:4.0f} m"
-    else:
-        what = f"{depth_from:4.0f} m -> {depth_to:3.0f} m"
-    return (
-        f"  {minutes(runtime):>9}  {what:<22} {minutes(segment.duration):>9}"
-        f"   {segment.gas.name:<6} {segment.kind.name}"
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -76,7 +65,7 @@ print(
 print()
 
 # ---------------------------------------------------------------------------
-# 2. Gases — named constructors, parsing, limits, best mix
+# 2. Gases — names, limits, best mix
 # ---------------------------------------------------------------------------
 print("=== 2. Gases ===")
 
@@ -106,53 +95,38 @@ print(
 print()
 
 # ---------------------------------------------------------------------------
-# 4. Run a deco model over it and query the result
+# 4. Run a deco model: a Dive — still in progress at this point
 # ---------------------------------------------------------------------------
-print("=== 4. DiveResult queries (ZHL-16C, GF 30/70) ===")
+print("=== 4. Dive queries (ZHL-16C, GF 30/70) ===")
 
-zhl = ZHL16C(gradient=Gradient(0.3, 0.7))
-carried = GasPlan(["air", "ean50"])  # gases by name, like everywhere else
-
-result = DiveResult.run(bottom, zhl)
+carried = GasPlan(["air", "ean50"])
+dive = Dive.run(bottom, ZHL16C(gradient="30/70"))
 
 for t in (5, 15, bottom.runtime):
-    ceiling = result.ceiling_at(t)
+    ceiling = dive.ceiling_at(t)
     depth = max(0.0, ceiling.depth_m)
     label = minutes(t if isinstance(t, timedelta) else timedelta(minutes=t))
     print(
         f"t={label}: ceiling {depth:4.1f} m   "
-        f"TTS {minutes(result.tts(t, gas_plan=carried))}"
+        f"TTS {minutes(dive.tts(t, gas_plan=carried))}"
     )
 
 # Tissue loading over time (leading compartment) — feed this to a plot:
 print("leading-compartment N2 tension (mbar):")
-for t, state in result.tissue_series(timedelta(minutes=9)):
+for t, state in dive.tissue_series(timedelta(minutes=9)):
     print(f"  t={minutes(t)}: {state.tissues[0][0]:6.0f}")
 print()
 
 # ---------------------------------------------------------------------------
-# 5. Plan the deco ascent and assemble the full dive
+# 5. Complete the dive with its planned deco ascent
 # ---------------------------------------------------------------------------
 print("=== 5. Ascent plan ===")
 
-end = bottom.runtime
-ascent = plan_ascent(
-    result.model_at(end),  # model positioned at end of bottom time
-    start_pressure=bottom.pressure_at(end),
-    gas=bottom.gas_at(end),
-    gas_plan=carried,
-    clock_offset=end,  # stop departures on whole minutes of dive runtime
-)
+ascent = dive.plan_ascent(carried)  # the deco schedule as segments
+full_dive = dive.extend(ascent)  # or in one step: dive.with_ascent(carried)
 
-full_dive = bottom.copy()
-full_dive.add_segments(ascent)  # seams stay policy-checked
-
-print("runtime    action                  duration   gas    kind")
-elapsed = timedelta(0)
-for segment in full_dive.segments:
-    print(describe(segment, elapsed))
-    elapsed += segment.duration
-print(f"total runtime : {minutes(full_dive.runtime)}")
+print(ConsoleFormatter.format_schedule(full_dive.profile.segments))
+print(f"total runtime : {minutes(full_dive.profile.runtime)}")
 deco_time = sum(
     (s.duration for s in ascent if s.kind is SegmentKind.Constant.STOP),
     timedelta(0),
@@ -161,20 +135,19 @@ print(f"total stops   : {minutes(deco_time)}")
 print()
 
 # ---------------------------------------------------------------------------
-# 6. Same dive, different models — the point of the result layer
+# 6. Same dive, different models — the point of the Dive layer
 # ---------------------------------------------------------------------------
 print("=== 6. Model comparison (same bottom, EAN50 carried) ===")
 
 candidates = [
     ("ZHL-16C raw", ZHL16C()),
-    ("ZHL-16C GF 30/70", ZHL16C(gradient=Gradient(0.3, 0.7))),
-    ("ZHL-16C GF 85/85", ZHL16C(gradient=Gradient(0.85, 0.85))),
+    ("ZHL-16C GF 30/70", ZHL16C(gradient="30/70")),
+    ("ZHL-16C GF 85/85", ZHL16C(gradient="85/85")),
     ("VPM-B +0 (pre-CVA)", VpmB(conservatism=0)),
     ("VPM-B +3 (pre-CVA)", VpmB(conservatism=3)),
 ]
 for name, model in candidates:
-    res = DiveResult.run(bottom, model)
-    tts = res.tts(bottom.runtime, gas_plan=carried)
+    tts = Dive.run(bottom, model).tts(bottom.runtime, gas_plan=carried)
     print(f"  {name:<20} TTS at end of bottom: {minutes(tts)}")
 print()
 
@@ -183,9 +156,9 @@ print()
 # ---------------------------------------------------------------------------
 print("=== 7. Serialization ===")
 
-payload = full_dive.to_json()
+payload = full_dive.profile.to_json()
 restored = DiveProfile.from_json(payload)
-assert restored.segments == full_dive.segments
+assert restored.segments == full_dive.profile.segments
 print(f"JSON round-trip OK ({len(payload)} bytes, {restored.segment_count} segments)")
 print()
 
@@ -194,19 +167,11 @@ print()
 # ---------------------------------------------------------------------------
 print("=== 8. Dive report ===")
 
-from diveplan import DiveReport  # noqa: E402
-from diveplan.dive.formatters import (  # noqa: E402
-    ConsoleFormatter,
-    JsonFormatter,
-    SubsurfaceXmlFormatter,
-)
-
-full_result = DiveResult.run(full_dive, zhl)
-report = DiveReport.from_result(
-    full_result,
+report = DiveReport.from_dive(
+    full_dive,
     # The "+1 m / +1 min" figures describe the *bottom* plan, so they are
-    # computed on the bottom result and handed to the report.
-    tts_variations=result.tts_variations(carried),
+    # computed on the in-progress dive and handed to the report.
+    tts_variations=dive.tts_variations(carried),
 )
 
 print(ConsoleFormatter().format(report))

--- a/examples/complete_dive_plan.py
+++ b/examples/complete_dive_plan.py
@@ -186,3 +186,34 @@ payload = full_dive.to_json()
 restored = DiveProfile.from_json(payload)
 assert restored.segments == full_dive.segments
 print(f"JSON round-trip OK ({len(payload)} bytes, {restored.segment_count} segments)")
+print()
+
+# ---------------------------------------------------------------------------
+# 8. Report — consumption, CNS/OTU, rock bottom, TTS variations, formatters
+# ---------------------------------------------------------------------------
+print("=== 8. Dive report ===")
+
+from diveplan import DiveReport  # noqa: E402
+from diveplan.dive.formatters import (  # noqa: E402
+    ConsoleFormatter,
+    JsonFormatter,
+    SubsurfaceXmlFormatter,
+)
+
+full_result = DiveResult.run(full_dive, zhl)
+report = DiveReport.from_result(
+    full_result,
+    # The "+1 m / +1 min" figures describe the *bottom* plan, so they are
+    # computed on the bottom result and handed to the report.
+    tts_variations=result.tts_variations(carried),
+)
+
+print(ConsoleFormatter().format(report))
+print()
+
+json_doc = JsonFormatter().format(report)
+print(f"JSON report: {len(json_doc)} bytes")
+
+xml_doc = SubsurfaceXmlFormatter().format(report)
+print(f"Subsurface XML: {len(xml_doc)} bytes — write to a .ssrf file and")
+print("import in Subsurface via File > Import > Import log files")

--- a/examples/complete_dive_plan.py
+++ b/examples/complete_dive_plan.py
@@ -62,13 +62,13 @@ print(
 print(f"deco ppO2 limit : {cfg.gas.deco_ppo2_bar} bar")
 
 # Scoped override (fresh water, altitude...) — nestable, thread-safe:
-sea_level_bar = Pressure.from_depth_m(30).bar
+sea_level_bar = Pressure.from_str("30 m").bar
 
 altitude = DiveConfig()
 altitude.physics.surface_pressure_mbar = 900
 altitude.physics.water_density = 1.0
 with altitude:
-    altitude_bar = Pressure.from_depth_m(30).bar
+    altitude_bar = Pressure.from_str("30 m").bar
 print(
     f"30 m of water column = {altitude_bar:.3f} bar at altitude/fresh water, "
     f"{sea_level_bar:.3f} bar at sea level/salt"
@@ -80,12 +80,13 @@ print()
 # ---------------------------------------------------------------------------
 print("=== 2. Gases ===")
 
-air = Gas.air()
-ean50 = Gas.from_name("ean50")  # or Gas.nitrox(0.50)
+# Gases parse from names: "air", "ean50"/"nx50", "tx21/35", "oxygen".
+air = Gas.from_name("air")
+ean50 = Gas.from_name("ean50")
 
 print(f"EAN50 MOD @1.6 bar : {ean50.mod(ppo2_bar=1.6).depth_m:.1f} m")
 print(f"best mix for 30 m  : {air.best_mix(30)}")
-print(f"air END at 40 m    : {air.end(Pressure.from_depth_m(40)).depth_m:.1f} m")
+print(f"air END at 40 m    : {air.end(Pressure.from_str('40 m')).depth_m:.1f} m")
 print()
 
 # ---------------------------------------------------------------------------
@@ -110,7 +111,7 @@ print()
 print("=== 4. DiveResult queries (ZHL-16C, GF 30/70) ===")
 
 zhl = ZHL16C(gradient=Gradient(0.3, 0.7))
-carried = GasPlan([air, ean50])
+carried = GasPlan(["air", "ean50"])  # gases by name, like everywhere else
 
 result = DiveResult.run(bottom, zhl)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,10 +28,10 @@ dev = ["pytest", "pytest-cov", "ruff", "mypy"]
 zhl16c = "diveplan.models.buhlmann.zhl16:ZHL16C"
 vpmb = "diveplan.models.vpm.model:VpmB"
 
-# Uncomment when the formatter modules land:
-# [project.entry-points."diveplan.formatters"]
-# json = "diveplan.dive.formatters.json:JSONFormatter"
-# csv = "diveplan.dive.formatters.csv:CSVFormatter"
+[project.entry-points."diveplan.formatters"]
+console = "diveplan.dive.formatters.console:ConsoleFormatter"
+json = "diveplan.dive.formatters.json:JsonFormatter"
+subsurface = "diveplan.dive.formatters.subsurface:SubsurfaceXmlFormatter"
 
 [tool.ruff]
 line-length = 88

--- a/src/diveplan/__init__.py
+++ b/src/diveplan/__init__.py
@@ -34,9 +34,9 @@ from diveplan.core.gas import Gas
 from diveplan.core.pressure import Pressure
 
 # -- dive / planning layers ------------------------------------------------
+from diveplan.dive.dive import Dive
 from diveplan.dive.dive_profile import DiveProfile
 from diveplan.dive.dive_report import DiveReport
-from diveplan.dive.dive_result import DiveResult
 from diveplan.planning.ascent_plan import plan_ascent
 from diveplan.planning.gas_plan import GasPlan
 
@@ -94,9 +94,9 @@ __all__ = [
     "DiveConfig",
     "diveconfig",
     # dive / planning layers
+    "Dive",
     "DiveProfile",
     "DiveReport",
-    "DiveResult",
     "GasPlan",
     "plan_ascent",
 ]

--- a/src/diveplan/__init__.py
+++ b/src/diveplan/__init__.py
@@ -35,6 +35,7 @@ from diveplan.core.pressure import Pressure
 
 # -- dive / planning layers ------------------------------------------------
 from diveplan.dive.dive_profile import DiveProfile
+from diveplan.dive.dive_report import DiveReport
 from diveplan.dive.dive_result import DiveResult
 from diveplan.planning.ascent_plan import plan_ascent
 from diveplan.planning.gas_plan import GasPlan
@@ -94,6 +95,7 @@ __all__ = [
     "diveconfig",
     # dive / planning layers
     "DiveProfile",
+    "DiveReport",
     "DiveResult",
     "GasPlan",
     "plan_ascent",

--- a/src/diveplan/core/config.py
+++ b/src/diveplan/core/config.py
@@ -209,6 +209,16 @@ class _GasConfig(_SubConfig):
         gt=0,
         description="L/min — surface air consumption at deco stops",
     )
+    sac_factor: float = Field(
+        default=2.0,
+        gt=0,
+        description="stress multiplier on SAC for rock-bottom/emergency planning",
+    )
+    problem_solving_minutes: float = Field(
+        default=1.0,
+        ge=0,
+        description="minutes spent solving a problem at depth (rock bottom)",
+    )
     gas_switch_minutes: float = Field(
         default=1.0,
         ge=0,

--- a/src/diveplan/dive/dive.py
+++ b/src/diveplan/dive/dive.py
@@ -1,20 +1,21 @@
-"""Result layer: a deco model run over a profile, queryable by time.
+"""Dive: a deco model run over a profile, queryable and extendable.
 
 The profile stays pure input geometry; everything a model computes lands
-here. A :class:`DiveResult` stores model-state **checkpoints at segment
-boundaries** only — O(segments) memory for batch runs — and answers
-time-addressed queries by re-integrating at most one segment from the
-nearest checkpoint (exact, since Haldane integration composes).
+here. A :class:`Dive` may be complete or in progress (just the bottom
+phase) — it stores model-state **checkpoints at segment boundaries** only
+(O(segments) memory for batch runs) and answers time-addressed queries by
+re-integrating at most one segment from the nearest checkpoint (exact,
+since Haldane integration composes).
 
-Queries:
+Queries and operations:
 
-- ``state_at(t)`` — model state at any runtime
-- ``ceiling_at(t)`` — ceiling at any runtime
+- ``state_at(t)`` / ``ceiling_at(t)`` — model state and ceiling at any runtime
 - ``tissue_series(dt)`` — (time, state) samples for visualization
-- ``tts(t)`` — time-to-surface: a counterfactual ascent planned from the
-  state at ``t`` (see :mod:`diveplan.planning.ascent_plan`)
+- ``tts(t)`` — time-to-surface: a counterfactual ascent planned from ``t``
+- ``plan_ascent()`` — the deco schedule from the dive's current end
+- ``with_ascent()`` / ``extend()`` — a new Dive continuing this one
 
-One profile can be run under any number of models/settings and the results
+One profile can be run under any number of models/settings and the dives
 compared — nothing here mutates the profile or the caller's model.
 """
 
@@ -30,7 +31,7 @@ from diveplan.models.base import BaseDecoModel, DecoState
 from diveplan.planning.ascent_plan import plan_ascent
 from diveplan.planning.gas_plan import GasPlan
 
-__all__ = ["DiveResult", "TtsVariations"]
+__all__ = ["Dive", "TtsVariations"]
 
 
 class TtsVariations(NamedTuple):
@@ -41,11 +42,13 @@ class TtsVariations(NamedTuple):
     per_minute: timedelta
 
 
-class DiveResult[StateT: DecoState]:
-    """A deco model's run over a profile: checkpoints + time queries.
+class Dive[StateT: DecoState]:
+    """A deco model's run over a profile — complete or still in progress.
 
-    Build via :meth:`run`. The result owns an independent model copy and a
-    copy of the profile's segment list; neither input is mutated.
+    Build via :meth:`run`. The dive owns an independent model copy and a
+    copy of the profile's segment list; neither input is mutated. Extend an
+    in-progress dive with :meth:`with_ascent` (plan and append the deco
+    schedule) or :meth:`extend` (append arbitrary segments).
     """
 
     __slots__ = ("_profile", "_model", "_checkpoints")
@@ -65,9 +68,7 @@ class DiveResult[StateT: DecoState]:
         self._checkpoints = checkpoints
 
     @classmethod
-    def run(
-        cls, profile: DiveProfile, model: BaseDecoModel[StateT]
-    ) -> "DiveResult[StateT]":
+    def run(cls, profile: DiveProfile, model: BaseDecoModel[StateT]) -> "Dive[StateT]":
         """Integrate `model` over `profile` and capture boundary checkpoints.
 
         The caller's model is copied, not mutated — run the same profile
@@ -86,7 +87,7 @@ class DiveResult[StateT: DecoState]:
 
     @property
     def profile(self) -> DiveProfile:
-        """The dive profile this result was computed from (own copy)."""
+        """The dive profile this dive was computed from (own copy)."""
         return self._profile
 
     @property
@@ -171,6 +172,53 @@ class DiveResult[StateT: DecoState]:
         )
         return sum((s.duration for s in ascent), timedelta(0))
 
+    # ------------------------------------------------------------------
+    # Continuing the dive
+    # ------------------------------------------------------------------
+
+    def plan_ascent(self, gas_plan: GasPlan | None = None) -> list[DiveSegment]:
+        """Deco schedule from the dive's current end to the surface.
+
+        Plans from the end-of-profile model state, depth, and gas, with stop
+        departures aligned to the dive clock. The dive itself is untouched —
+        use :meth:`with_ascent` to get a new Dive that includes the ascent.
+
+        Args:
+            gas_plan: Gases available for the ascent. Defaults to all gases
+                appearing in the profile so far.
+        """
+        end = self._profile.runtime
+        if gas_plan is None:
+            gas_plan = GasPlan(self._unique_gases())
+        return plan_ascent(
+            self.model_at(end),
+            start_pressure=self._profile.pressure_at(end),
+            gas=self._profile.gas_at(end),
+            gas_plan=gas_plan,
+            clock_offset=end,
+        )
+
+    def extend(self, segments: list[DiveSegment]) -> "Dive[StateT]":
+        """New Dive with `segments` appended and integrated.
+
+        Cheap: the existing checkpoints are reused and only the new segments
+        are integrated. The profile's builder policy applies to the new
+        seams; this dive is not modified.
+        """
+        new_profile = self._profile.copy()
+        new_profile.add_segments(segments)
+
+        work = self._model.copy()  # already holds the end-of-profile state
+        checkpoints = list(self._checkpoints)
+        for segment in segments:
+            checkpoints.append(work.integrate_segment(segment))
+        return Dive(new_profile, work, tuple(checkpoints))
+
+    def with_ascent(self, gas_plan: GasPlan | None = None) -> "Dive[StateT]":
+        """New Dive completed with its planned deco ascent —
+        ``dive.extend(dive.plan_ascent(gas_plan))``."""
+        return self.extend(self.plan_ascent(gas_plan))
+
     def tts_variations(self, gas_plan: GasPlan | None = None) -> TtsVariations:
         """Extra time-to-surface per +1 m on the final segment and per +1 min
         of extra time at the current depth (both re-planned, not estimated).
@@ -245,7 +293,7 @@ class DiveResult[StateT: DecoState]:
 
     def __repr__(self) -> str:
         return (
-            f"DiveResult({type(self._model).__name__}, "
+            f"Dive({type(self._model).__name__}, "
             f"{self._profile.segment_count} segments, "
             f"runtime={self._profile.runtime})"
         )

--- a/src/diveplan/dive/dive_report.py
+++ b/src/diveplan/dive/dive_report.py
@@ -1,6 +1,6 @@
 """Dive report: everything about a computed dive, ready for presentation.
 
-:class:`DiveReport` is pure data assembled from a :class:`DiveResult` — the
+:class:`DiveReport` is pure data assembled from a :class:`~diveplan.dive.dive.Dive` — the
 schedule rows plus derived figures (gas consumption, CNS/OTU, rock bottom,
 TTS variations). Formatters (`diveplan.dive.formatters`) turn a report into
 console text, JSON, or a Subsurface dive log; they never touch models or
@@ -13,7 +13,7 @@ from typing import NamedTuple, Optional
 from diveplan.core.gas import Gas
 from diveplan.core.pressure import Pressure
 from diveplan.dive.dive_profile import DiveProfile
-from diveplan.dive.dive_result import DiveResult, TtsVariations
+from diveplan.dive.dive import Dive, TtsVariations
 from diveplan.dive.oxygen import cns_percent, otu
 from diveplan.models.base import DecoState
 from diveplan.planning.gas_plan import GasPlan, gas_consumption, rock_bottom
@@ -35,7 +35,7 @@ class ReportRow(NamedTuple):
 class DiveReport:
     """Immutable summary of a computed dive.
 
-    Build via :meth:`from_result`. Holds the schedule and the derived
+    Build via :meth:`from_dive`. Holds the schedule and the derived
     numbers; formatting belongs to `diveplan.dive.formatters`.
     """
 
@@ -89,26 +89,26 @@ class DiveReport:
         self.tts_variations = tts_variations
 
     @classmethod
-    def from_result(
+    def from_dive(
         cls,
-        result: DiveResult[DecoState],
+        dive: Dive[DecoState],
         *,
         gas_plan: Optional[GasPlan] = None,
         tts_variations: Optional[TtsVariations] = None,
     ) -> "DiveReport":
-        """Assemble a report from a dive result.
+        """Assemble a report from a computed dive.
 
         Args:
-            result: The computed dive (normally over the *full* profile,
-                bottom + planned ascent).
+            dive: The computed dive (normally the *full* dive, bottom plus
+                planned ascent — see :meth:`Dive.with_ascent`).
             gas_plan: Unused for consumption (which follows the profile's
                 own gases) — reserved for future reserve summaries.
             tts_variations: The "+1 m / +1 min" figures. They are meaningful
-                for a *bottom-phase* profile, so compute them on the bottom
-                result (``bottom_result.tts_variations()``) and pass them
-                here; a report over a full dive cannot derive them itself.
+                for a *bottom-phase* dive, so compute them on the bottom
+                dive (``bottom.tts_variations()``) and pass them here; a
+                report over a full dive cannot derive them itself.
         """
-        profile = result.profile
+        profile = dive.profile
         segments = profile.segments
 
         rows: list[ReportRow] = []
@@ -133,7 +133,7 @@ class DiveReport:
 
         return cls(
             profile=profile,
-            model_name=result.model_name,
+            model_name=dive.model_name,
             rows=tuple(rows),
             runtime=profile.runtime,
             max_depth=max_pressure,

--- a/src/diveplan/dive/dive_report.py
+++ b/src/diveplan/dive/dive_report.py
@@ -1,0 +1,151 @@
+"""Dive report: everything about a computed dive, ready for presentation.
+
+:class:`DiveReport` is pure data assembled from a :class:`DiveResult` — the
+schedule rows plus derived figures (gas consumption, CNS/OTU, rock bottom,
+TTS variations). Formatters (`diveplan.dive.formatters`) turn a report into
+console text, JSON, or a Subsurface dive log; they never touch models or
+profiles directly, so a new output format is a single class.
+"""
+
+from datetime import timedelta
+from typing import NamedTuple, Optional
+
+from diveplan.core.gas import Gas
+from diveplan.core.pressure import Pressure
+from diveplan.dive.dive_profile import DiveProfile
+from diveplan.dive.dive_result import DiveResult, TtsVariations
+from diveplan.dive.oxygen import cns_percent, otu
+from diveplan.models.base import DecoState
+from diveplan.planning.gas_plan import GasPlan, gas_consumption, rock_bottom
+
+__all__ = ["DiveReport", "ReportRow"]
+
+
+class ReportRow(NamedTuple):
+    """One schedule line: a segment with its cumulative runtime at the end."""
+
+    runtime: timedelta  # at the END of the segment
+    start_depth_m: float
+    end_depth_m: float
+    duration: timedelta
+    gas: Gas
+    kind: str  # SegmentKind member name
+
+
+class DiveReport:
+    """Immutable summary of a computed dive.
+
+    Build via :meth:`from_result`. Holds the schedule and the derived
+    numbers; formatting belongs to `diveplan.dive.formatters`.
+    """
+
+    __slots__ = (
+        "profile",
+        "model_name",
+        "rows",
+        "runtime",
+        "max_depth",
+        "consumption_l",
+        "cns",
+        "otus",
+        "rock_bottom_l",
+        "tts_variations",
+    )
+
+    profile: DiveProfile
+    model_name: str
+    rows: tuple[ReportRow, ...]
+    runtime: timedelta
+    max_depth: Pressure
+    consumption_l: tuple[tuple[Gas, float], ...]
+    cns: float
+    otus: float
+    rock_bottom_l: float
+    tts_variations: Optional[TtsVariations]
+
+    def __init__(
+        self,
+        *,
+        profile: DiveProfile,
+        model_name: str,
+        rows: tuple[ReportRow, ...],
+        runtime: timedelta,
+        max_depth: Pressure,
+        consumption_l: tuple[tuple[Gas, float], ...],
+        cns: float,
+        otus: float,
+        rock_bottom_l: float,
+        tts_variations: Optional[TtsVariations],
+    ):
+        self.profile = profile
+        self.model_name = model_name
+        self.rows = rows
+        self.runtime = runtime
+        self.max_depth = max_depth
+        self.consumption_l = consumption_l
+        self.cns = cns
+        self.otus = otus
+        self.rock_bottom_l = rock_bottom_l
+        self.tts_variations = tts_variations
+
+    @classmethod
+    def from_result(
+        cls,
+        result: DiveResult[DecoState],
+        *,
+        gas_plan: Optional[GasPlan] = None,
+        tts_variations: Optional[TtsVariations] = None,
+    ) -> "DiveReport":
+        """Assemble a report from a dive result.
+
+        Args:
+            result: The computed dive (normally over the *full* profile,
+                bottom + planned ascent).
+            gas_plan: Unused for consumption (which follows the profile's
+                own gases) — reserved for future reserve summaries.
+            tts_variations: The "+1 m / +1 min" figures. They are meaningful
+                for a *bottom-phase* profile, so compute them on the bottom
+                result (``bottom_result.tts_variations()``) and pass them
+                here; a report over a full dive cannot derive them itself.
+        """
+        profile = result.profile
+        segments = profile.segments
+
+        rows: list[ReportRow] = []
+        elapsed = timedelta(0)
+        for segment in segments:
+            elapsed += segment.duration
+            rows.append(
+                ReportRow(
+                    runtime=elapsed,
+                    start_depth_m=segment.start_pressure.depth_m,
+                    end_depth_m=segment.end_pressure.depth_m,
+                    duration=segment.duration,
+                    gas=segment.gas,
+                    kind=segment.kind.name,
+                )
+            )
+
+        max_pressure = max(
+            (p for s in segments for p in (s.start_pressure, s.end_pressure)),
+            default=Pressure.surface(),
+        )
+
+        return cls(
+            profile=profile,
+            model_name=result.model_name,
+            rows=tuple(rows),
+            runtime=profile.runtime,
+            max_depth=max_pressure,
+            consumption_l=tuple(gas_consumption(segments).items()),
+            cns=cns_percent(segments),
+            otus=otu(segments),
+            rock_bottom_l=rock_bottom(max_pressure),
+            tts_variations=tts_variations,
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"DiveReport({self.model_name}, {len(self.rows)} rows, "
+            f"runtime={self.runtime}, max depth {self.max_depth.depth_m:.1f} m)"
+        )

--- a/src/diveplan/dive/dive_result.py
+++ b/src/diveplan/dive/dive_result.py
@@ -19,17 +19,26 @@ compared — nothing here mutates the profile or the caller's model.
 """
 
 from datetime import timedelta
-from typing import Iterator
+from typing import Any, Iterator, NamedTuple
 
-from diveplan.core.dive_segment import DiveSegment
+from diveplan.core.config import DiveConfig
+from diveplan.core.dive_segment import DiveSegment, SegmentKind
 from diveplan.core.gas import Gas
 from diveplan.core.pressure import Pressure
-from diveplan.dive.dive_profile import DiveProfile, _as_timedelta
+from diveplan.dive.dive_profile import DiveProfile, ProfileBuilderPolicy, _as_timedelta
 from diveplan.models.base import BaseDecoModel, DecoState
 from diveplan.planning.ascent_plan import plan_ascent
 from diveplan.planning.gas_plan import GasPlan
 
-__all__ = ["DiveResult"]
+__all__ = ["DiveResult", "TtsVariations"]
+
+
+class TtsVariations(NamedTuple):
+    """Sensitivity of the time-to-surface to small plan changes — the
+    "+x /m +y /min" figures planners print next to a runtime."""
+
+    per_meter: timedelta
+    per_minute: timedelta
 
 
 class DiveResult[StateT: DecoState]:
@@ -162,6 +171,66 @@ class DiveResult[StateT: DecoState]:
         )
         return sum((s.duration for s in ascent), timedelta(0))
 
+    def tts_variations(self, gas_plan: GasPlan | None = None) -> TtsVariations:
+        """Extra time-to-surface per +1 m on the final segment and per +1 min
+        of extra time at the current depth (both re-planned, not estimated).
+
+        Meaningful when the profile ends in the bottom phase (the normal
+        planning situation): "+1 m" re-runs the model over the profile with
+        its final segment shifted one metre deeper (a transition is inserted
+        automatically), "+1 min" extends the dive by a minute at the final
+        depth. Deltas are clamped at zero — clock-aligned stop rounding can
+        otherwise produce a spurious −few-seconds.
+        """
+        if gas_plan is None:
+            gas_plan = GasPlan(self._unique_gases())
+        end = self._profile.runtime
+        base = self.tts(end, gas_plan)
+
+        # +1 minute at the current depth.
+        end_pressure = self._profile.pressure_at(end)
+        end_gas = self._profile.gas_at(end)
+        longer = self.model_at(end)
+        longer.integrate_segment(DiveSegment(end_pressure, end_pressure, 1, end_gas))
+        plus_minute = _ascent_duration(
+            longer, end_pressure, end_gas, gas_plan, end + timedelta(minutes=1)
+        )
+
+        # Final segment 1 m deeper, transition auto-inserted, model re-run.
+        delta_mbar = round(DiveConfig.current().physics.pressure_per_meter_mbar)
+        last = self._profile.segments[-1]
+        deeper = DiveSegment(
+            Pressure(last.start_pressure.mbar + delta_mbar),
+            Pressure(last.end_pressure.mbar + delta_mbar),
+            last.duration,
+            last.gas,
+            ascent_kind=last.kind
+            if isinstance(last.kind, SegmentKind.Ascent)
+            else SegmentKind.ASCENT,
+            constant_kind=last.kind
+            if isinstance(last.kind, SegmentKind.Constant)
+            else SegmentKind.CONSTANT,
+        )
+        variant = self._profile.copy(
+            override_policy=ProfileBuilderPolicy.ALLOW_BAD_PROFILE
+        )
+        variant.replace_segment_at_index(-1, deeper)
+        variant.fix_continuity()
+
+        deep_model = self._model.copy()
+        deep_model.set_state(self._checkpoints[0])
+        for segment in variant.segments:
+            deep_model.integrate_segment(segment)
+        plus_meter = _ascent_duration(
+            deep_model, deeper.end_pressure, deeper.gas, gas_plan, variant.runtime
+        )
+
+        zero = timedelta(0)
+        return TtsVariations(
+            per_meter=max(zero, plus_meter - base),
+            per_minute=max(zero, plus_minute - base),
+        )
+
     def _unique_gases(self) -> list[Gas]:
         gases: list[Gas] = []
         for segment in self._profile.segments:
@@ -169,9 +238,31 @@ class DiveResult[StateT: DecoState]:
                 gases.append(segment.gas)
         return gases
 
+    @property
+    def model_name(self) -> str:
+        """Registry name of the model this result was computed with."""
+        return getattr(type(self._model), "NAME", type(self._model).__name__)
+
     def __repr__(self) -> str:
         return (
             f"DiveResult({type(self._model).__name__}, "
             f"{self._profile.segment_count} segments, "
             f"runtime={self._profile.runtime})"
         )
+
+
+def _ascent_duration(
+    model: BaseDecoModel[Any],
+    start_pressure: Pressure,
+    gas: Gas,
+    gas_plan: GasPlan,
+    clock_offset: timedelta,
+) -> timedelta:
+    plan = plan_ascent(
+        model,
+        start_pressure=start_pressure,
+        gas=gas,
+        gas_plan=gas_plan,
+        clock_offset=clock_offset,
+    )
+    return sum((s.duration for s in plan), timedelta(0))

--- a/src/diveplan/dive/formatters/__init__.py
+++ b/src/diveplan/dive/formatters/__init__.py
@@ -1,0 +1,30 @@
+"""Report formatters: turn a DiveReport into an output document.
+
+A formatter is a class with a ``NAME`` and a ``format(report) -> str``
+method — stateless, presentation only. Third-party formatters can register
+under the ``diveplan.formatters`` entry-point group.
+"""
+
+from abc import ABC, abstractmethod
+from typing import ClassVar
+
+from diveplan.dive.dive_report import DiveReport
+
+__all__ = ["BaseFormatter"]
+
+
+class BaseFormatter(ABC):
+    """Base class for all report formatters."""
+
+    NAME: ClassVar[str]
+
+    @abstractmethod
+    def format(self, report: DiveReport) -> str:
+        """Render the report as a string in this formatter's output format."""
+
+
+from diveplan.dive.formatters.console import ConsoleFormatter  # noqa: E402
+from diveplan.dive.formatters.json import JsonFormatter  # noqa: E402
+from diveplan.dive.formatters.subsurface import SubsurfaceXmlFormatter  # noqa: E402
+
+__all__ += ["ConsoleFormatter", "JsonFormatter", "SubsurfaceXmlFormatter"]

--- a/src/diveplan/dive/formatters/console.py
+++ b/src/diveplan/dive/formatters/console.py
@@ -1,18 +1,22 @@
 """Plain-text report formatter for terminals and logs."""
 
+from collections.abc import Iterable
 from datetime import timedelta
 
+from diveplan.core.dive_segment import DiveSegment
 from diveplan.dive.dive_report import DiveReport, ReportRow
 from diveplan.dive.formatters import BaseFormatter
 
 __all__ = ["ConsoleFormatter"]
+
+_SCHEDULE_HEADER = "  runtime     action                  duration   gas    kind"
 
 
 def _minutes(td: timedelta) -> str:
     return f"{td.total_seconds() / 60:6.1f} min"
 
 
-def _describe(row: ReportRow) -> str:
+def _row_line(row: ReportRow) -> str:
     if row.kind == "GAS_SWITCH":
         action = f"switch to {row.gas}"
     elif row.start_depth_m == row.end_depth_m:
@@ -31,6 +35,26 @@ class ConsoleFormatter(BaseFormatter):
 
     NAME = "console"
 
+    @staticmethod
+    def format_schedule(segments: Iterable[DiveSegment]) -> str:
+        """Render any segment sequence (a profile's or an ascent plan) as a
+        runtime table — reusable outside full reports."""
+        rows: list[ReportRow] = []
+        elapsed = timedelta(0)
+        for segment in segments:
+            elapsed += segment.duration
+            rows.append(
+                ReportRow(
+                    runtime=elapsed,
+                    start_depth_m=segment.start_pressure.depth_m,
+                    end_depth_m=segment.end_pressure.depth_m,
+                    duration=segment.duration,
+                    gas=segment.gas,
+                    kind=segment.kind.name,
+                )
+            )
+        return "\n".join([_SCHEDULE_HEADER, *map(_row_line, rows)])
+
     def format(self, report: DiveReport) -> str:
         lines = [
             f"Dive plan — {report.model_name}",
@@ -44,8 +68,8 @@ class ConsoleFormatter(BaseFormatter):
                 f"TTS variation: +{per_m / 60:.1f} min/m, +{per_min / 60:.1f} min/min"
             )
         lines.append("")
-        lines.append("  runtime     action                  duration   gas    kind")
-        lines.extend(_describe(row) for row in report.rows)
+        lines.append(_SCHEDULE_HEADER)
+        lines.extend(_row_line(row) for row in report.rows)
         lines.append("")
 
         for gas, litres in report.consumption_l:

--- a/src/diveplan/dive/formatters/console.py
+++ b/src/diveplan/dive/formatters/console.py
@@ -1,0 +1,58 @@
+"""Plain-text report formatter for terminals and logs."""
+
+from datetime import timedelta
+
+from diveplan.dive.dive_report import DiveReport, ReportRow
+from diveplan.dive.formatters import BaseFormatter
+
+__all__ = ["ConsoleFormatter"]
+
+
+def _minutes(td: timedelta) -> str:
+    return f"{td.total_seconds() / 60:6.1f} min"
+
+
+def _describe(row: ReportRow) -> str:
+    if row.kind == "GAS_SWITCH":
+        action = f"switch to {row.gas}"
+    elif row.start_depth_m == row.end_depth_m:
+        action = f"hold {row.start_depth_m:4.0f} m"
+    else:
+        action = f"{row.start_depth_m:4.0f} m -> {row.end_depth_m:3.0f} m"
+    runtime_start = row.runtime - row.duration
+    return (
+        f"  {_minutes(runtime_start)}  {action:<22}"
+        f"{_minutes(row.duration)}   {row.gas.name:<6} {row.kind}"
+    )
+
+
+class ConsoleFormatter(BaseFormatter):
+    """Human-readable dive plan table with a summary block."""
+
+    NAME = "console"
+
+    def format(self, report: DiveReport) -> str:
+        lines = [
+            f"Dive plan — {report.model_name}",
+            f"runtime {_minutes(report.runtime).strip()}, "
+            f"max depth {report.max_depth.depth_m:.1f} m",
+        ]
+        if report.tts_variations is not None:
+            per_m = report.tts_variations.per_meter.total_seconds()
+            per_min = report.tts_variations.per_minute.total_seconds()
+            lines.append(
+                f"TTS variation: +{per_m / 60:.1f} min/m, +{per_min / 60:.1f} min/min"
+            )
+        lines.append("")
+        lines.append("  runtime     action                  duration   gas    kind")
+        lines.extend(_describe(row) for row in report.rows)
+        lines.append("")
+
+        for gas, litres in report.consumption_l:
+            lines.append(f"  {gas.name:<6} consumed : {litres:7.0f} L")
+        lines.append(
+            f"  rock bottom @ {report.max_depth.depth_m:.0f} m : "
+            f"{report.rock_bottom_l:7.0f} L"
+        )
+        lines.append(f"  CNS {report.cns:.0f} %   OTU {report.otus:.0f}")
+        return "\n".join(lines)

--- a/src/diveplan/dive/formatters/json.py
+++ b/src/diveplan/dive/formatters/json.py
@@ -1,0 +1,58 @@
+"""JSON report formatter — machine-readable dive plan document."""
+
+import json
+
+from diveplan.dive.dive_report import DiveReport
+from diveplan.dive.formatters import BaseFormatter
+
+__all__ = ["JsonFormatter"]
+
+
+class JsonFormatter(BaseFormatter):
+    """Serialize the whole report to a JSON document.
+
+    Depths in metres, durations in seconds, gases by name with exact
+    fractions alongside.
+    """
+
+    NAME = "json"
+
+    def __init__(self, *, indent: int | None = 2):
+        self.indent = indent
+
+    def format(self, report: DiveReport) -> str:
+        variations = None
+        if report.tts_variations is not None:
+            variations = {
+                "per_meter_s": report.tts_variations.per_meter.total_seconds(),
+                "per_minute_s": report.tts_variations.per_minute.total_seconds(),
+            }
+
+        document = {
+            "model": report.model_name,
+            "runtime_s": report.runtime.total_seconds(),
+            "max_depth_m": round(report.max_depth.depth_m, 2),
+            "segments": [
+                {
+                    "runtime_s": row.runtime.total_seconds(),
+                    "start_depth_m": round(row.start_depth_m, 2),
+                    "end_depth_m": round(row.end_depth_m, 2),
+                    "duration_s": row.duration.total_seconds(),
+                    "gas": {
+                        "name": row.gas.name,
+                        "fo2": row.gas.fo2,
+                        "fhe": row.gas.fhe,
+                    },
+                    "kind": row.kind,
+                }
+                for row in report.rows
+            ],
+            "consumption_l": {
+                gas.name: round(litres, 1) for gas, litres in report.consumption_l
+            },
+            "rock_bottom_l": round(report.rock_bottom_l, 1),
+            "cns_percent": round(report.cns, 1),
+            "otu": round(report.otus, 1),
+            "tts_variations": variations,
+        }
+        return json.dumps(document, indent=self.indent)

--- a/src/diveplan/dive/formatters/subsurface.py
+++ b/src/diveplan/dive/formatters/subsurface.py
@@ -1,0 +1,127 @@
+"""Subsurface dive-log XML formatter (experimental).
+
+Emits a minimal Subsurface-compatible dive log: one dive with cylinders
+(one per gas), a planned-dive computer with depth samples and gas-change
+events. Written against Subsurface's XML dive-log format as of v6; treat
+as experimental until round-tripped through your Subsurface version —
+the importer is lenient, but the format is theirs, not a public standard.
+"""
+
+from datetime import datetime, timedelta
+from xml.etree import ElementTree
+
+from diveplan.core.gas import Gas
+from diveplan.dive.dive_report import DiveReport
+from diveplan.dive.formatters import BaseFormatter
+
+__all__ = ["SubsurfaceXmlFormatter"]
+
+
+def _mmss(td: timedelta) -> str:
+    total = round(td.total_seconds())
+    return f"{total // 60}:{total % 60:02d} min"
+
+
+def _depth(metres: float) -> str:
+    return f"{max(0.0, metres):.1f} m"
+
+
+def _gas_attrs(gas: Gas) -> dict[str, str]:
+    attrs = {"o2": f"{gas.fo2 * 100:.1f}%"}
+    if gas.fhe > 0:
+        attrs["he"] = f"{gas.fhe * 100:.1f}%"
+    return attrs
+
+
+class SubsurfaceXmlFormatter(BaseFormatter):
+    """Render the report as a Subsurface dive-log XML document."""
+
+    NAME = "subsurface"
+
+    SAMPLE_STEP = timedelta(seconds=10)
+
+    def __init__(self, *, planned_at: datetime | None = None):
+        self.planned_at = planned_at if planned_at is not None else datetime.now()
+
+    def format(self, report: DiveReport) -> str:
+        profile = report.profile
+        segments = profile.segments
+
+        divelog = ElementTree.Element(
+            "divelog", {"program": "diveplan", "version": "3"}
+        )
+        dives = ElementTree.SubElement(divelog, "dives")
+        dive = ElementTree.SubElement(
+            dives,
+            "dive",
+            {
+                "number": "1",
+                "date": self.planned_at.strftime("%Y-%m-%d"),
+                "time": self.planned_at.strftime("%H:%M:%S"),
+                "duration": _mmss(report.runtime),
+            },
+        )
+
+        # One cylinder per distinct gas, in order of first use.
+        gases: list[Gas] = []
+        for segment in segments:
+            if segment.gas not in gases:
+                gases.append(segment.gas)
+        for gas in gases:
+            ElementTree.SubElement(
+                dive, "cylinder", {**_gas_attrs(gas), "description": gas.name}
+            )
+
+        computer = ElementTree.SubElement(
+            dive, "divecomputer", {"model": "diveplan (planned dive)"}
+        )
+
+        # Time-weighted mean depth (exact for linear segments).
+        total_s = report.runtime.total_seconds()
+        mean_m = 0.0
+        if total_s > 0:
+            weighted = sum(
+                s.average_pressure.depth_m * s.duration.total_seconds()
+                for s in segments
+            )
+            mean_m = weighted / total_s
+        ElementTree.SubElement(
+            computer,
+            "depth",
+            {"max": _depth(report.max_depth.depth_m), "mean": _depth(mean_m)},
+        )
+
+        # Gas-change events at the segment boundaries where the gas changes.
+        elapsed = timedelta(0)
+        current_gas = segments[0].gas if segments else None
+        for segment in segments:
+            if segment.gas != current_gas:
+                ElementTree.SubElement(
+                    computer,
+                    "event",
+                    {
+                        "time": _mmss(elapsed),
+                        "name": "gaschange",
+                        "cylinder": str(gases.index(segment.gas)),
+                        **_gas_attrs(segment.gas),
+                    },
+                )
+                current_gas = segment.gas
+            elapsed += segment.duration
+
+        # Depth samples on a fixed grid (plus the exact start and end).
+        ElementTree.SubElement(
+            computer, "sample", {"time": _mmss(timedelta(0)), "depth": _depth(0.0)}
+        )
+        for sample in profile.iter_samples(self.SAMPLE_STEP):
+            ElementTree.SubElement(
+                computer,
+                "sample",
+                {
+                    "time": _mmss(sample.time),
+                    "depth": _depth(sample.pressure.depth_m),
+                },
+            )
+
+        ElementTree.indent(divelog)
+        return ElementTree.tostring(divelog, encoding="unicode", xml_declaration=True)

--- a/src/diveplan/dive/oxygen.py
+++ b/src/diveplan/dive/oxygen.py
@@ -1,0 +1,110 @@
+"""Oxygen-exposure tracking: NOAA CNS clock and REPEX OTUs.
+
+Both accumulate over any sequence of segments (a profile's or an ascent
+plan's). Constant-depth segments are evaluated in closed form; segments with
+changing depth are integrated numerically at midpoint ppO2 with a
+configurable step.
+
+- **CNS %** — fraction of the NOAA single-exposure oxygen limit consumed:
+  ``Σ dt / limit(ppO2)``. Limits are linearly interpolated between the NOAA
+  table nodes; below 0.5 bar ppO2 nothing accrues; above 1.6 bar the last
+  table slope is extrapolated with a floor (exposure that far past the
+  limits is out of tested territory — treat those numbers as "far too
+  much", not as physiology).
+- **OTU** — pulmonary (whole-body) toxicity units, REPEX formula:
+  ``dt · ((ppO2 − 0.5)/0.5)^0.83`` per minute above 0.5 bar.
+"""
+
+import math
+from collections.abc import Iterable
+from datetime import timedelta
+
+from diveplan.core.dive_segment import DiveSegment
+
+__all__ = ["cns_percent", "otu", "NOAA_CNS_LIMITS"]
+
+# NOAA single-exposure oxygen limits: (ppO2 bar, max minutes), ascending.
+NOAA_CNS_LIMITS: tuple[tuple[float, float], ...] = (
+    (0.6, 720.0),
+    (0.7, 570.0),
+    (0.8, 450.0),
+    (0.9, 360.0),
+    (1.0, 300.0),
+    (1.1, 240.0),
+    (1.2, 210.0),
+    (1.3, 180.0),
+    (1.4, 150.0),
+    (1.5, 120.0),
+    (1.6, 45.0),
+)
+
+_CNS_PPO2_FLOOR = 0.5
+_OTU_PPO2_FLOOR = 0.5
+# Slope of the last table interval (1.5 -> 1.6 bar: 120 -> 45 min).
+_EXTRAPOLATION_SLOPE = (45.0 - 120.0) / 0.1
+_MIN_LIMIT_MINUTES = 4.0
+
+
+def _cns_limit_minutes(ppo2_bar: float) -> float | None:
+    """NOAA limit at `ppo2_bar`, linearly interpolated; None below the floor."""
+    if ppo2_bar <= _CNS_PPO2_FLOOR:
+        return None
+    first_ppo2, first_limit = NOAA_CNS_LIMITS[0]
+    if ppo2_bar <= first_ppo2:
+        return first_limit
+
+    last_ppo2, last_limit = NOAA_CNS_LIMITS[-1]
+    if ppo2_bar > last_ppo2:
+        extrapolated = last_limit + _EXTRAPOLATION_SLOPE * (ppo2_bar - last_ppo2)
+        return max(_MIN_LIMIT_MINUTES, extrapolated)
+
+    for (lo_p, lo_lim), (hi_p, hi_lim) in zip(
+        NOAA_CNS_LIMITS, NOAA_CNS_LIMITS[1:], strict=False
+    ):
+        if lo_p <= ppo2_bar <= hi_p:
+            fraction = (ppo2_bar - lo_p) / (hi_p - lo_p)
+            return lo_lim + (hi_lim - lo_lim) * fraction
+    raise AssertionError("unreachable")  # table scan is exhaustive
+
+
+def _iter_ppo2(
+    segments: Iterable[DiveSegment], step: timedelta
+) -> Iterable[tuple[float, float]]:
+    """Yield (minutes, ppO2 bar) exposures: one per constant segment, midpoint
+    sub-steps for depth-changing segments."""
+    for segment in segments:
+        minutes = segment.duration.total_seconds() / 60.0
+        if minutes <= 0:
+            continue
+        if segment.start_pressure == segment.end_pressure:
+            yield minutes, segment.gas.ppo2(segment.start_pressure).bar
+            continue
+
+        substeps = max(1, math.ceil(segment.duration / step))
+        sub_minutes = minutes / substeps
+        for i in range(substeps):
+            midpoint = segment.pressure_at_fraction((i + 0.5) / substeps)
+            yield sub_minutes, segment.gas.ppo2(midpoint).bar
+
+
+def cns_percent(
+    segments: Iterable[DiveSegment], *, step: timedelta = timedelta(seconds=10)
+) -> float:
+    """CNS oxygen-toxicity clock over `segments`, in percent (100 = NOAA limit)."""
+    total = 0.0
+    for minutes, ppo2 in _iter_ppo2(segments, step):
+        limit = _cns_limit_minutes(ppo2)
+        if limit is not None:
+            total += minutes / limit
+    return total * 100.0
+
+
+def otu(
+    segments: Iterable[DiveSegment], *, step: timedelta = timedelta(seconds=10)
+) -> float:
+    """Pulmonary oxygen-toxicity units (REPEX) accumulated over `segments`."""
+    total = 0.0
+    for minutes, ppo2 in _iter_ppo2(segments, step):
+        if ppo2 > _OTU_PPO2_FLOOR:
+            total += minutes * ((ppo2 - _OTU_PPO2_FLOOR) / 0.5) ** 0.83
+    return total

--- a/src/diveplan/models/buhlmann/common.py
+++ b/src/diveplan/models/buhlmann/common.py
@@ -53,6 +53,29 @@ class Gradient:
         self.gf_low = gf_low
         self.gf_high = gf_high
 
+    @classmethod
+    def from_str(cls, s: str) -> "Gradient":
+        """Parse the usual GF notation: ``"30/70"``, ``"GF 30/70"``, ``"85/85"``.
+
+        Numbers are percentages (the way divers write them); ``"100/100"``
+        is raw Bühlmann.
+
+        Raises:
+            ValueError: If the string is not two /-separated numbers.
+        """
+        text = s.strip().lower().removeprefix("gf").strip()
+        parts = text.split("/")
+        if len(parts) != 2:
+            raise ValueError(
+                f"Cannot parse gradient factors from {s!r} — expected 'low/high' "
+                f"percentages like '30/70'."
+            )
+        try:
+            low, high = (float(p.strip()) for p in parts)
+        except ValueError:
+            raise ValueError(f"Cannot parse gradient factors from {s!r}.") from None
+        return cls(low / 100.0, high / 100.0)
+
     def __repr__(self) -> str:
         return f"Gradient(gf_low={self.gf_low}, gf_high={self.gf_high})"
 

--- a/src/diveplan/models/buhlmann/model.py
+++ b/src/diveplan/models/buhlmann/model.py
@@ -80,7 +80,8 @@ class BuhlmannModel(BaseDecoModel[BuhlmannState]):
     read from ``DiveConfig.current().planning.sample_rate_s`` at construction.
 
     Args:
-        gradient: GF pair; defaults to ``Gradient(1.0, 1.0)`` (raw Bühlmann).
+        gradient: GF pair — a :class:`Gradient` or the usual string notation
+            (``"30/70"``, percentages). Defaults to raw Bühlmann (GF 100/100).
     """
 
     # Coefficient tables — supplied by concrete subclasses.
@@ -115,7 +116,7 @@ class BuhlmannModel(BaseDecoModel[BuhlmannState]):
         if 0 in lengths.values():
             raise TypeError(f"{cls.__name__} coefficient tables are empty.")
 
-    def __init__(self, gradient: Gradient | None = None):
+    def __init__(self, gradient: Gradient | str | None = None):
         if not hasattr(type(self), "N2_HALF_TIMES"):
             raise TypeError(
                 "BuhlmannModel is an abstract engine — instantiate a concrete "
@@ -123,7 +124,12 @@ class BuhlmannModel(BaseDecoModel[BuhlmannState]):
             )
         super().__init__()
         self.sample_rate_seconds = DiveConfig.current().planning.sample_rate_s
-        self.gradient = gradient if gradient is not None else Gradient(1.0, 1.0)
+        if gradient is None:
+            self.gradient = Gradient(1.0, 1.0)
+        elif isinstance(gradient, str):
+            self.gradient = Gradient.from_str(gradient)
+        else:
+            self.gradient = gradient
         self._compartments = [
             Compartment(
                 ht_n2=self.N2_HALF_TIMES[i],

--- a/src/diveplan/planning/ascent_plan.py
+++ b/src/diveplan/planning/ascent_plan.py
@@ -33,6 +33,7 @@ from diveplan.core.pressure import Pressure
 from diveplan.models.base import BaseDecoModel
 from diveplan.models.buhlmann.model import BuhlmannModel
 from diveplan.planning.gas_plan import GasPlan
+from diveplan.utils.conversions import coerce_depth_to_pressure, coerce_gas
 
 __all__ = ["plan_ascent", "AscentNotConvergingError"]
 
@@ -75,8 +76,8 @@ def _next_targets(current: Pressure) -> list[Pressure]:
 
 def plan_ascent(
     model: BaseDecoModel[Any],
-    start_pressure: Pressure,
-    gas: Gas,
+    start_pressure: Pressure | str | float,
+    gas: Gas | str,
     gas_plan: Optional[GasPlan] = None,
     clock_offset: timedelta | float = timedelta(0),
 ) -> list[DiveSegment]:
@@ -85,8 +86,9 @@ def plan_ascent(
     Args:
         model: Deco model holding the tissue state at `start_pressure`.
             Cloned internally — the caller's instance is not touched.
-        start_pressure: Current ambient pressure.
-        gas: Gas currently being breathed.
+        start_pressure: Current position — a Pressure, a "40 m"-style
+            string, or bare metres.
+        gas: Gas currently being breathed — a Gas or a name like "ean50".
         gas_plan: Gases available for switches during the ascent. Defaults
             to just the current gas.
         clock_offset: Dive runtime at which this ascent starts (minutes or
@@ -109,6 +111,8 @@ def plan_ascent(
     gas_limits = DiveConfig.current().gas
     surface = Pressure.surface()
 
+    start_pressure = coerce_depth_to_pressure(start_pressure)
+    gas = coerce_gas(gas)
     if gas_plan is None:
         gas_plan = GasPlan([gas])
     if not isinstance(clock_offset, timedelta):

--- a/src/diveplan/planning/gas_plan.py
+++ b/src/diveplan/planning/gas_plan.py
@@ -18,7 +18,7 @@ from diveplan.core.config import DiveConfig
 from diveplan.core.dive_segment import DiveSegment, SegmentKind
 from diveplan.core.gas import Gas
 from diveplan.core.pressure import Pressure
-from diveplan.utils.conversions import coerce_depth_to_pressure
+from diveplan.utils.conversions import coerce_depth_to_pressure, coerce_gas
 
 __all__ = ["GasPlan", "gas_consumption", "rock_bottom"]
 
@@ -31,17 +31,22 @@ _DECO_KINDS = (
 
 
 class GasPlan:
-    """An ordered collection of carried gases with depth-based selection."""
+    """An ordered collection of carried gases with depth-based selection.
+
+    Gases may be given as :class:`Gas` objects or names — ``GasPlan(["air",
+    "ean50"])`` — parsed via :meth:`Gas.from_name`.
+    """
 
     __slots__ = ("_gases",)
 
     _gases: tuple[Gas, ...]
 
-    def __init__(self, gases: Iterable[Gas]):
+    def __init__(self, gases: Iterable[Gas | str]):
         unique: list[Gas] = []
         for gas in gases:
-            if gas not in unique:
-                unique.append(gas)
+            mix = coerce_gas(gas)
+            if mix not in unique:
+                unique.append(mix)
         if not unique:
             raise ValueError("GasPlan needs at least one gas.")
         self._gases = tuple(unique)

--- a/src/diveplan/planning/gas_plan.py
+++ b/src/diveplan/planning/gas_plan.py
@@ -1,20 +1,33 @@
-"""Gas plan: the set of gases carried on a dive, and which to breathe when.
+"""Gas plan: carried gases, selection, consumption, and reserve planning.
 
 Selection reads the ppO2 limits from ``DiveConfig.current().gas`` at call
 time: a gas is usable at a pressure if its ppO2 sits within
 ``[min_ppo2_bar, deco_ppo2_bar]`` (the deco limit — the planner switches
 gases during ascent, where the deco ppO2 applies). Among usable gases the
 richest (highest fO2) wins: it off-gasses inert load fastest.
+
+Also provides :func:`gas_consumption` (surface litres per gas over any
+sequence of segments — a profile's or a plan's) and :func:`rock_bottom`
+(the minimum reserve for an emergency shared-gas direct ascent).
 """
 
 from collections.abc import Iterable
 from typing import Optional
 
 from diveplan.core.config import DiveConfig
+from diveplan.core.dive_segment import DiveSegment, SegmentKind
 from diveplan.core.gas import Gas
 from diveplan.core.pressure import Pressure
+from diveplan.utils.conversions import coerce_depth_to_pressure
 
-__all__ = ["GasPlan"]
+__all__ = ["GasPlan", "gas_consumption", "rock_bottom"]
+
+# Segment kinds billed at the deco SAC rate; everything else uses bottom SAC.
+_DECO_KINDS = (
+    SegmentKind.Ascent.DECO_ASCENT,
+    SegmentKind.Constant.STOP,
+    SegmentKind.Constant.GAS_SWITCH,
+)
 
 
 class GasPlan:
@@ -54,3 +67,65 @@ class GasPlan:
 
     def __repr__(self) -> str:
         return f"GasPlan({', '.join(str(g) for g in self._gases)})"
+
+
+# ---------------------------------------------------------------------------
+# Consumption and reserve planning
+# ---------------------------------------------------------------------------
+
+
+def gas_consumption(segments: Iterable[DiveSegment]) -> dict[Gas, float]:
+    """Surface litres of each gas consumed over `segments`.
+
+    Per segment: ``SAC × mean ambient pressure (atm) × minutes`` — exact,
+    since the mean pressure of a linear traverse is its midpoint. Deco
+    phases (deco ascents, stops, gas switches) are billed at
+    ``gas.sac_deco``, everything else at ``gas.sac_bottom``. Works on a
+    profile's segments or on a plan from :func:`plan_ascent`.
+    """
+    limits = DiveConfig.current().gas
+    totals: dict[Gas, float] = {}
+    for segment in segments:
+        sac = limits.sac_deco if segment.kind in _DECO_KINDS else limits.sac_bottom
+        minutes = segment.duration.total_seconds() / 60.0
+        litres = sac * segment.average_pressure.atm * minutes
+        totals[segment.gas] = totals.get(segment.gas, 0.0) + litres
+    return totals
+
+
+def rock_bottom(
+    depth: Pressure | str | float,
+    *,
+    divers: int = 2,
+) -> float:
+    """Minimum gas reserve (surface litres) at `depth` for an emergency.
+
+    Models the classic worst case: `divers` divers (out-of-gas buddy plus
+    donor) breathe from one supply at a stressed rate
+    (``sac_bottom × sac_factor``) while solving the problem at depth for
+    ``problem_solving_minutes``, then ascend directly to the surface at the
+    configured ascent rate. Decompression stops are **not** included —
+    this is a direct-ascent reserve; divide by cylinder size × working
+    pressure to express it in bar.
+
+    Args:
+        depth: Depth as a Pressure, a "40 m"-style string, or bare metres.
+        divers: Divers sharing the supply. Defaults to 2.
+
+    Raises:
+        ValueError: If `divers` is not strictly positive.
+    """
+    if divers <= 0:
+        raise ValueError(f"divers must be > 0, got {divers}")
+
+    cfg = DiveConfig.current()
+    pressure = coerce_depth_to_pressure(depth)
+
+    stressed_sac = cfg.gas.sac_bottom * cfg.gas.sac_factor * divers
+    solving = stressed_sac * pressure.atm * cfg.gas.problem_solving_minutes
+
+    ascent_minutes = max(0.0, pressure.depth_m) / cfg.planning.ascent_rate
+    mean_atm = (pressure.atm + 1.0) / 2.0  # linear ascent to the surface
+    ascent = stressed_sac * mean_atm * ascent_minutes
+
+    return solving + ascent

--- a/tests/test_buhlmann.py
+++ b/tests/test_buhlmann.py
@@ -94,6 +94,19 @@ class TestGradient:
     def test_str(self):
         assert str(Gradient(0.3, 0.85)) == "GF 30/85"
 
+    def test_from_str(self):
+        assert Gradient.from_str("30/70") == Gradient(0.3, 0.7)
+        assert Gradient.from_str("GF 85/85") == Gradient(0.85, 0.85)
+        assert Gradient.from_str(" 100 / 100 ") == Gradient(1.0, 1.0)
+
+    def test_from_str_invalid(self):
+        with pytest.raises(ValueError, match="low/high"):
+            Gradient.from_str("30-70")
+        with pytest.raises(ValueError):
+            Gradient.from_str("thirty/seventy")
+        with pytest.raises(ValueError):  # zero factor rejected by Gradient
+            Gradient.from_str("0/85")
+
 
 # ------------------------------------------------------------------
 # Compartment
@@ -239,6 +252,11 @@ class TestZHL16CModel:
     def test_sample_rate_from_config(self):
         DiveConfig.current().planning.sample_rate_s = 4
         assert ZHL16C().sample_rate_seconds == 4
+
+    def test_gradient_accepts_string_notation(self):
+        assert ZHL16C(gradient="30/70").gradient == Gradient(0.3, 0.7)
+        assert ZHL16C(gradient=Gradient(0.3, 0.7)).gradient == Gradient(0.3, 0.7)
+        assert ZHL16C().gradient == Gradient(1.0, 1.0)
 
     def test_no_deco_short_shallow_dive(self):
         # 12 m for 10 min on air is far inside any no-stop limit.

--- a/tests/test_dive.py
+++ b/tests/test_dive.py
@@ -1,5 +1,5 @@
 """
-Tests for diveplan.dive.dive_result (and DiveProfile.iter_samples).
+Tests for diveplan.dive.dive (Dive) (and DiveProfile.iter_samples).
 
 Key invariants: iter_samples steps tile the runtime exactly and never cross
 segment boundaries; running a model through iter_samples reproduces
@@ -12,8 +12,9 @@ from datetime import timedelta
 import pytest
 
 from diveplan.core.gas import Gas
+from diveplan.core.pressure import Pressure
 from diveplan.dive.dive_profile import DiveProfile
-from diveplan.dive.dive_result import DiveResult
+from diveplan.dive.dive import Dive
 from diveplan.models.buhlmann.common import Gradient
 from diveplan.models.buhlmann.zhl16 import ZHL16C
 from diveplan.models.vpm.model import VpmB
@@ -113,14 +114,14 @@ class TestIterSamples:
 
 
 # ------------------------------------------------------------------
-# DiveResult
+# Dive
 # ------------------------------------------------------------------
 
 
-class TestDiveResultRun:
+class TestDiveRun:
     def test_checkpoint_shape(self):
         profile = simple_profile()
-        result = DiveResult.run(profile, ZHL16C())
+        result = Dive.run(profile, ZHL16C())
         assert len(result.checkpoints) == profile.segment_count + 1
         assert result.checkpoints[0] == ZHL16C().get_state()  # pre-dive
         assert result.final_state == result.checkpoints[-1]
@@ -130,27 +131,27 @@ class TestDiveResultRun:
         model = ZHL16C()
         before = model.get_state()
         segment_count = profile.segment_count
-        DiveResult.run(profile, model)
+        Dive.run(profile, model)
         assert model.get_state() == before
         assert profile.segment_count == segment_count
 
     def test_result_profile_is_a_copy(self):
         profile = simple_profile()
-        result = DiveResult.run(profile, ZHL16C())
+        result = Dive.run(profile, ZHL16C())
         assert result.profile is not profile
         assert result.profile.segments == profile.segments
 
     def test_generic_over_models(self):
         profile = simple_profile()
         for model in (ZHL16C(gradient=Gradient(0.3, 0.85)), VpmB(conservatism=1)):
-            result = DiveResult.run(profile, model)
+            result = Dive.run(profile, model)
             assert len(result.checkpoints) == profile.segment_count + 1
 
 
-class TestDiveResultQueries:
+class TestDiveQueries:
     def test_state_at_boundaries_equals_checkpoints(self):
         profile = simple_profile()
-        result = DiveResult.run(profile, ZHL16C())
+        result = Dive.run(profile, ZHL16C())
         assert result.state_at(0) == result.checkpoints[0]
         assert result.state_at(profile.runtime) == result.final_state
 
@@ -158,7 +159,7 @@ class TestDiveResultQueries:
         # state_at re-integrates from the checkpoint; compare against a
         # model integrated directly to the same instant.
         profile = simple_profile()
-        result = DiveResult.run(profile, ZHL16C())
+        result = Dive.run(profile, ZHL16C())
         t = profile.start_time_of_segment(1) + timedelta(minutes=7)
 
         direct = ZHL16C()
@@ -178,7 +179,7 @@ class TestDiveResultQueries:
 
     def test_ceiling_rises_with_bottom_time(self):
         profile = simple_profile()
-        result = DiveResult.run(profile, ZHL16C())
+        result = Dive.run(profile, ZHL16C())
         bottom_start = profile.start_time_of_segment(1)
         early = result.ceiling_at(bottom_start + timedelta(minutes=2))
         late = result.ceiling_at(bottom_start + timedelta(minutes=19))
@@ -186,7 +187,7 @@ class TestDiveResultQueries:
 
     def test_tissue_series_shape(self):
         profile = simple_profile()
-        result = DiveResult.run(profile, ZHL16C())
+        result = Dive.run(profile, ZHL16C())
         series = list(result.tissue_series(timedelta(minutes=1)))
         assert series[0][0] == timedelta(0)
         assert series[0][1] == result.checkpoints[0]
@@ -198,7 +199,7 @@ class TestDiveResultQueries:
         # same step size — coarser sampling is approximate by design).
         profile = simple_profile()
         model = ZHL16C()
-        result = DiveResult.run(profile, model)
+        result = Dive.run(profile, model)
         series = list(
             result.tissue_series(timedelta(seconds=model.sample_rate_seconds))
         )
@@ -210,7 +211,7 @@ class TestDiveResultQueries:
 
     def test_queries_do_not_mutate_result(self):
         profile = simple_profile()
-        result = DiveResult.run(profile, ZHL16C())
+        result = Dive.run(profile, ZHL16C())
         final_before = result.final_state
         result.state_at(5)
         result.ceiling_at(15)
@@ -221,7 +222,7 @@ class TestDiveResultQueries:
         from diveplan.core.config import DiveConfig
 
         profile = DiveProfile().descend_to("12 m").stay(10).surface()
-        result = DiveResult.run(profile, ZHL16C())
+        result = Dive.run(profile, ZHL16C())
         t = profile.start_time_of_segment(1) + timedelta(minutes=5)
         expected = timedelta(minutes=12 / DiveConfig.current().planning.ascent_rate)
         assert abs(result.tts(t) - expected) < timedelta(seconds=5)
@@ -234,9 +235,60 @@ class TestDiveResultQueries:
             .stay(30)
             .surface()
         )
-        result = DiveResult.run(profile, ZHL16C(gradient=Gradient(0.3, 0.7)))
+        result = Dive.run(profile, ZHL16C(gradient=Gradient(0.3, 0.7)))
         bottom_start = profile.start_time_of_segment(1)
         early = result.tts(bottom_start + timedelta(minutes=5))
         late = result.tts(bottom_start + timedelta(minutes=25))
         assert late > early
         assert late > timedelta(minutes=10)  # real deco obligation
+
+
+# ------------------------------------------------------------------
+# Continuing a dive: plan_ascent / extend / with_ascent
+# ------------------------------------------------------------------
+
+
+class TestDiveContinuation:
+    def make_bottom_dive(self):
+        from diveplan.planning.gas_plan import GasPlan
+
+        bottom = DiveProfile().descend_to("40 m").stay(25)
+        dive = Dive.run(bottom, ZHL16C(gradient=Gradient(0.3, 0.7)))
+        return dive, GasPlan(["air", "ean50"])
+
+    def test_plan_ascent_reaches_surface(self):
+        dive, gases = self.make_bottom_dive()
+        ascent = dive.plan_ascent(gases)
+        assert ascent[0].start_pressure == Pressure.from_depth_m(40)
+        assert ascent[-1].end_pressure == Pressure.surface()
+
+    def test_extend_appends_and_reuses_checkpoints(self):
+        dive, gases = self.make_bottom_dive()
+        ascent = dive.plan_ascent(gases)
+        full = dive.extend(ascent)
+
+        # Original dive untouched; new dive covers everything.
+        assert dive.profile.segment_count == 2
+        assert full.profile.segment_count == 2 + len(ascent)
+        assert len(full.checkpoints) == full.profile.segment_count + 1
+        assert full.checkpoints[: len(dive.checkpoints)] == dive.checkpoints
+
+    def test_extend_equivalent_to_fresh_run(self):
+        dive, gases = self.make_bottom_dive()
+        full = dive.with_ascent(gases)
+        rerun = Dive.run(full.profile, ZHL16C(gradient=Gradient(0.3, 0.7)))
+        for (a_n2, a_he), (b_n2, b_he) in zip(
+            full.final_state.tissues, rerun.final_state.tissues, strict=True
+        ):
+            assert a_n2 == pytest.approx(b_n2, rel=1e-9)
+            assert a_he == pytest.approx(b_he, rel=1e-9)
+
+    def test_with_ascent_surfaces_clean(self):
+        dive, gases = self.make_bottom_dive()
+        full = dive.with_ascent(gases)
+        assert full.profile.segments[-1].end_pressure == Pressure.surface()
+        # At surfacing the GF-high ceiling must clear the surface (that is
+        # the planner's criterion; the default get_ceiling() is the
+        # conservative GF-low bound and legitimately does not).
+        surfaced = full.model_at(full.profile.runtime)
+        assert surfaced.get_ceiling(0.7) <= Pressure.surface()

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -55,6 +55,10 @@ class TestGasPlan:
         plan = GasPlan([AIR, EAN50, AIR])
         assert plan.gases == (AIR, EAN50)
 
+    def test_accepts_gas_names(self):
+        assert GasPlan(["air", "ean50"]).gases == (AIR, EAN50)
+        assert GasPlan(["tx21/35", AIR]).gases == (Gas.trimix(0.21, 0.35), AIR)
+
     def test_breathability_window(self):
         # EAN50 at 21 m: ppO2 ≈ 1.56 bar — inside the 1.6 deco limit.
         assert GasPlan.is_breathable(EAN50, Pressure.from_depth_m(21))
@@ -126,6 +130,13 @@ class TestPlanAscentNoDeco:
     def test_already_at_surface(self):
         plan = plan_ascent(ZHL16C(), Pressure.surface(), AIR)
         assert plan == []
+
+    def test_friendly_argument_coercion(self):
+        # Depths as "12 m" strings, gases by name — like the fluent builders.
+        model = loaded_model(12, 10, Gradient(1.0, 1.0))
+        plan = plan_ascent(model, "12 m", "air")
+        assert plan[0].start_pressure == Pressure.from_depth_m(12)
+        assert plan[0].gas == AIR
 
     def test_input_model_not_mutated(self):
         model = loaded_model(40, 25, Gradient(0.3, 0.7))

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -218,9 +218,10 @@ class TestPlanAscentDeco:
             elapsed += segment.duration
             if segment.kind is SegmentKind.Constant.STOP:
                 departure_s = elapsed.total_seconds()
-                assert departure_s % 60 == pytest.approx(0, abs=0.51) or (
-                    60 - departure_s % 60
-                ) < 0.51
+                assert (
+                    departure_s % 60 == pytest.approx(0, abs=0.51)
+                    or (60 - departure_s % 60) < 0.51
+                )
 
     def test_vpm_plan_terminates_and_is_well_formed(self):
         model = VpmB()

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,250 @@
+"""
+Tests for gas consumption, rock bottom, CNS/OTU, TTS variations, DiveReport,
+and the formatters.
+
+Consumption and rock bottom are checked against hand-computed arithmetic
+(they are closed-form). CNS uses the exact NOAA table nodes (45 min at
+ppO2 1.6 = 100 %); OTU uses the exact identity that ppO2 1.0 accrues one
+unit per minute. Formatters are checked structurally (parseable, right
+fields), not against golden strings.
+"""
+
+import json as jsonlib
+from datetime import timedelta
+from xml.etree import ElementTree
+
+import pytest
+
+from diveplan.core.config import DiveConfig
+from diveplan.core.dive_segment import DiveSegment, SegmentKind
+from diveplan.core.gas import Gas
+from diveplan.core.pressure import Pressure
+from diveplan.dive.dive_profile import DiveProfile
+from diveplan.dive.dive_report import DiveReport
+from diveplan.dive.dive_result import DiveResult, TtsVariations
+from diveplan.dive.formatters import (
+    ConsoleFormatter,
+    JsonFormatter,
+    SubsurfaceXmlFormatter,
+)
+from diveplan.dive.oxygen import cns_percent, otu
+from diveplan.models.buhlmann.common import Gradient
+from diveplan.models.buhlmann.zhl16 import ZHL16C
+from diveplan.planning.ascent_plan import plan_ascent
+from diveplan.planning.gas_plan import GasPlan, gas_consumption, rock_bottom
+
+AIR = Gas.air()
+EAN50 = Gas.nitrox(0.50)
+
+
+def two_atm() -> Pressure:
+    """Ambient pressure of exactly 2 atm under the current config."""
+    return Pressure.from_atm(2.0)
+
+
+# ------------------------------------------------------------------
+# Gas consumption
+# ------------------------------------------------------------------
+
+
+class TestGasConsumption:
+    def test_bottom_segment_exact(self):
+        # 10 min at exactly 2 atm, bottom SAC 20 L/min -> 400 L.
+        seg = DiveSegment(two_atm(), two_atm(), 10, AIR)
+        assert gas_consumption([seg]) == {AIR: pytest.approx(400.0)}
+
+    def test_deco_kinds_use_deco_sac(self):
+        DiveConfig.current().gas.sac_deco = 10.0
+        stop = DiveSegment(
+            two_atm(), two_atm(), 10, AIR, constant_kind=SegmentKind.Constant.STOP
+        )
+        assert gas_consumption([stop]) == {AIR: pytest.approx(200.0)}
+
+    def test_linear_traverse_uses_mean_pressure(self):
+        # Descent 1 atm -> 3 atm over 5 min: mean 2 atm, SAC 20 -> 200 L.
+        seg = DiveSegment(Pressure.from_atm(1.0), Pressure.from_atm(3.0), 5, AIR)
+        assert gas_consumption([seg])[AIR] == pytest.approx(200.0, rel=1e-3)
+
+    def test_totals_split_per_gas(self):
+        a = DiveSegment(two_atm(), two_atm(), 10, AIR)
+        b = DiveSegment(
+            two_atm(), two_atm(), 5, EAN50, constant_kind=SegmentKind.Constant.STOP
+        )
+        totals = gas_consumption([a, b])
+        assert set(totals) == {AIR, EAN50}
+        assert totals[AIR] == pytest.approx(400.0)
+        assert totals[EAN50] == pytest.approx(150.0)  # deco SAC 15 by default
+
+
+# ------------------------------------------------------------------
+# Rock bottom
+# ------------------------------------------------------------------
+
+
+class TestRockBottom:
+    def test_hand_computed(self):
+        # Defaults: SAC 20, factor 2, 2 divers, 1 min solving, ascent 9 m/min.
+        cfg = DiveConfig.current()
+        depth = Pressure.from_depth_m(30)
+        stressed = 20.0 * 2.0 * 2  # 80 L/min
+        # Use the quantized pressure's own depth — from_depth_m rounds to
+        # integer mbar, so "30 m" is not exactly 30.0 m coming back.
+        expected = stressed * depth.atm * 1.0 + stressed * ((depth.atm + 1.0) / 2.0) * (
+            depth.depth_m / cfg.planning.ascent_rate
+        )
+        assert rock_bottom("30 m") == pytest.approx(expected)
+
+    def test_monotonic_with_depth(self):
+        assert rock_bottom(40) > rock_bottom(30) > rock_bottom(20)
+
+    def test_scales_with_config(self):
+        base = rock_bottom(30)
+        DiveConfig.current().gas.sac_factor = 4.0
+        assert rock_bottom(30) == pytest.approx(base * 2.0)
+
+    def test_divers_validation(self):
+        with pytest.raises(ValueError):
+            rock_bottom(30, divers=0)
+
+    def test_zero_at_surface_with_no_solving_time(self):
+        DiveConfig.current().gas.problem_solving_minutes = 0.0
+        assert rock_bottom(Pressure.surface()) == pytest.approx(0.0)
+
+
+# ------------------------------------------------------------------
+# CNS / OTU
+# ------------------------------------------------------------------
+
+
+def segment_at_ppo2(ppo2_bar: float, minutes: float, gas: Gas = AIR) -> DiveSegment:
+    """Constant-depth segment where `gas` gives exactly `ppo2_bar`."""
+    pressure = Pressure.from_bar(ppo2_bar / gas.fo2)
+    return DiveSegment(pressure, pressure, minutes, gas)
+
+
+class TestOxygenExposure:
+    def test_cns_100_percent_at_table_node(self):
+        # NOAA: 45 min at ppO2 1.6 is exactly the single-exposure limit.
+        seg = segment_at_ppo2(1.6, 45, EAN50)
+        assert cns_percent([seg]) == pytest.approx(100.0, rel=1e-3)
+
+    def test_cns_zero_below_floor(self):
+        seg = segment_at_ppo2(0.4, 60)
+        assert cns_percent([seg]) == 0.0
+
+    def test_cns_interpolates_between_nodes(self):
+        # ppO2 1.45 -> limit between 150 (1.4) and 120 (1.5) = 135 min.
+        seg = segment_at_ppo2(1.45, 135, EAN50)
+        assert cns_percent([seg]) == pytest.approx(100.0, rel=5e-3)
+
+    def test_cns_additive_over_segments(self):
+        half = segment_at_ppo2(1.6, 22.5, EAN50)
+        assert cns_percent([half, half]) == pytest.approx(100.0, rel=1e-3)
+
+    def test_otu_unit_rate_at_ppo2_one(self):
+        # ((1.0 - 0.5)/0.5)^0.83 = 1 -> one OTU per minute.
+        seg = segment_at_ppo2(1.0, 30)
+        assert otu([seg]) == pytest.approx(30.0, rel=1e-6)
+
+    def test_otu_zero_below_floor(self):
+        assert otu([segment_at_ppo2(0.5, 60)]) == 0.0
+
+    def test_changing_depth_integrates(self):
+        # Descent through varying ppO2 accrues something between the
+        # endpoint rates.
+        start, end = Pressure.from_bar(1.0 / 0.21), Pressure.from_bar(1.4 / 0.21)
+        seg = DiveSegment(start, end, 10, AIR)
+        accrued = otu([seg])
+        assert 10.0 < accrued < 10.0 * ((1.4 - 0.5) / 0.5) ** 0.83
+
+
+# ------------------------------------------------------------------
+# TTS variations
+# ------------------------------------------------------------------
+
+
+class TestTtsVariations:
+    def test_deco_dive_variations_positive_and_sane(self):
+        bottom = DiveProfile().descend_to("40 m").stay(25)
+        result = DiveResult.run(bottom, ZHL16C(gradient=Gradient(0.3, 0.7)))
+        variations = result.tts_variations(GasPlan([AIR, EAN50]))
+        assert variations.per_meter >= timedelta(0)
+        assert variations.per_minute > timedelta(0)
+        assert variations.per_meter < timedelta(minutes=10)
+        assert variations.per_minute < timedelta(minutes=10)
+
+
+# ------------------------------------------------------------------
+# DiveReport + formatters
+# ------------------------------------------------------------------
+
+
+def full_dive_report() -> DiveReport:
+    bottom = DiveProfile().descend_to("40 m").stay(25)
+    gases = GasPlan([AIR, EAN50])
+    model = ZHL16C(gradient=Gradient(0.3, 0.7))
+    bottom_result = DiveResult.run(bottom, model)
+
+    end = bottom.runtime
+    ascent = plan_ascent(
+        bottom_result.model_at(end),
+        start_pressure=bottom.pressure_at(end),
+        gas=bottom.gas_at(end),
+        gas_plan=gases,
+        clock_offset=end,
+    )
+    full = bottom.copy()
+    full.add_segments(ascent)
+    full_result = DiveResult.run(full, model)
+    return DiveReport.from_result(
+        full_result, tts_variations=bottom_result.tts_variations(gases)
+    )
+
+
+class TestDiveReport:
+    def test_fields(self):
+        report = full_dive_report()
+        assert report.model_name == "zhl16c"
+        assert report.max_depth == Pressure.from_depth_m(40)
+        assert report.runtime == report.rows[-1].runtime
+        assert len(report.rows) == report.profile.segment_count
+        assert {g for g, _ in report.consumption_l} == {AIR, EAN50}
+        assert all(litres > 0 for _, litres in report.consumption_l)
+        assert 0 < report.cns < 100
+        assert report.otus > 0
+        assert report.rock_bottom_l == pytest.approx(rock_bottom(40), rel=1e-6)
+        assert isinstance(report.tts_variations, TtsVariations)
+
+    def test_console_formatter(self):
+        text = ConsoleFormatter().format(full_dive_report())
+        assert "zhl16c" in text
+        assert "switch to EAN50" in text
+        assert "CNS" in text and "OTU" in text
+        assert "rock bottom" in text
+        assert "TTS variation" in text
+
+    def test_json_formatter_round_trips(self):
+        document = jsonlib.loads(JsonFormatter().format(full_dive_report()))
+        assert document["model"] == "zhl16c"
+        assert document["max_depth_m"] == pytest.approx(40.0, abs=0.1)
+        assert document["segments"][0]["kind"] == "DESCENT"
+        assert document["consumption_l"]["EAN50"] > 0
+        assert document["cns_percent"] > 0
+        assert document["tts_variations"]["per_minute_s"] > 0
+
+    def test_subsurface_formatter_structure(self):
+        xml = SubsurfaceXmlFormatter().format(full_dive_report())
+        root = ElementTree.fromstring(xml)
+        assert root.tag == "divelog"
+        dive = root.find("./dives/dive")
+        assert dive is not None
+        cylinders = dive.findall("cylinder")
+        assert [c.get("o2") for c in cylinders] == ["21.0%", "50.0%"]
+        computer = dive.find("divecomputer")
+        assert computer is not None
+        samples = computer.findall("sample")
+        assert len(samples) > 100  # 10 s grid over ~1 h
+        events = computer.findall("event")
+        assert any(e.get("name") == "gaschange" for e in events)
+        depth = computer.find("depth")
+        assert depth is not None and depth.get("max") == "40.0 m"

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -21,7 +21,7 @@ from diveplan.core.gas import Gas
 from diveplan.core.pressure import Pressure
 from diveplan.dive.dive_profile import DiveProfile
 from diveplan.dive.dive_report import DiveReport
-from diveplan.dive.dive_result import DiveResult, TtsVariations
+from diveplan.dive.dive import Dive, TtsVariations
 from diveplan.dive.formatters import (
     ConsoleFormatter,
     JsonFormatter,
@@ -166,7 +166,7 @@ class TestOxygenExposure:
 class TestTtsVariations:
     def test_deco_dive_variations_positive_and_sane(self):
         bottom = DiveProfile().descend_to("40 m").stay(25)
-        result = DiveResult.run(bottom, ZHL16C(gradient=Gradient(0.3, 0.7)))
+        result = Dive.run(bottom, ZHL16C(gradient=Gradient(0.3, 0.7)))
         variations = result.tts_variations(GasPlan([AIR, EAN50]))
         assert variations.per_meter >= timedelta(0)
         assert variations.per_minute > timedelta(0)
@@ -183,7 +183,7 @@ def full_dive_report() -> DiveReport:
     bottom = DiveProfile().descend_to("40 m").stay(25)
     gases = GasPlan([AIR, EAN50])
     model = ZHL16C(gradient=Gradient(0.3, 0.7))
-    bottom_result = DiveResult.run(bottom, model)
+    bottom_result = Dive.run(bottom, model)
 
     end = bottom.runtime
     ascent = plan_ascent(
@@ -195,8 +195,8 @@ def full_dive_report() -> DiveReport:
     )
     full = bottom.copy()
     full.add_segments(ascent)
-    full_result = DiveResult.run(full, model)
-    return DiveReport.from_result(
+    full_result = Dive.run(full, model)
+    return DiveReport.from_dive(
         full_result, tts_variations=bottom_result.tts_variations(gases)
     )
 


### PR DESCRIPTION
## Summary

Stacked on #5 (merge order: #2 → #3 → #4 → #5 → this). Three commits:

**Consumption & exposure** — `gas_consumption(segments)`: surface litres per gas, exact per linear segment (SAC × mean atm × minutes), deco phases billed at `sac_deco`. `rock_bottom(depth)`: emergency shared-gas direct-ascent reserve (divers × stressed SAC for problem-solving at depth + the ascent), with new config fields `sac_factor` / `problem_solving_minutes` mirroring Subsurface's gas options. `dive/oxygen.py`: NOAA CNS clock (interpolated table, documented extrapolation past 1.6 bar) and REPEX OTU. All three take `Iterable[DiveSegment]` — they work on profiles and on plans.

**TTS variations** — `DiveResult.tts_variations()`: the "+x /m +y /min" figures, computed as true replans (final segment 1 m deeper with an auto-inserted transition and full model re-run; one extra minute at the final depth), not linear estimates.

**Report + formatters** — `DiveReport.from_result()` is pure data (rows, runtime, max depth, consumption, CNS/OTU, rock bottom, optional variations); formatters are presentation-only classes under the `diveplan.formatters` entry-point group: **console** table, **JSON** document, and an experimental **Subsurface dive-log XML** (cylinders, 10 s samples, gaschange events) for import into Subsurface.

## Validation

Cross-checked against a real Subsurface plan of the same dive (40 m/25 min, air + EAN50, GF 30/70): **CNS 18 vs 17 %, OTU 50 vs 51, air 2,746 vs 2,807 L**; the EAN50 difference (736 vs 991 L) is exactly the deco-SAC setting (ours 15, theirs 20 L/min — 736 × 20/15 ≈ 981).

## Testing

449 tests pass (21 new: closed-form consumption/rock-bottom arithmetic, exact NOAA node and OTU identities, interpolation checks, variation sanity, formatter structure incl. XML parse), strict mypy clean, ruff clean.

⚠️ The Subsurface XML formatter is best-effort against their format — please try importing the example's output into your Subsurface and report back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)